### PR TITLE
Store traces during computation optionally

### DIFF
--- a/nanshe_workflow/proj.py
+++ b/nanshe_workflow/proj.py
@@ -34,12 +34,15 @@ def stack_compute_traces_parallel(client, num_frames):
             callable:             parallelized callable.
     """
 
-    def compute_traces(imagestack, rois):
-        traces_dtype = numpy.dtype(float)
-        if issubclass(imagestack.dtype.type, numpy.floating):
-            traces_dtype = imagestack.dtype
+    def compute_traces(imagestack, rois, out=None):
+        if out is None:
+            traces_dtype = numpy.dtype(float)
+            if issubclass(imagestack.dtype.type, numpy.floating):
+                traces_dtype = imagestack.dtype
 
-        traces = numpy.empty((len(rois), len(imagestack)), dtype=traces_dtype)
+            traces = numpy.empty((len(rois), len(imagestack)), dtype=traces_dtype)
+        else:
+            traces = out
 
         trace_func = lambda d, r: (d[...][:, r].mean(axis=1))
 


### PR DESCRIPTION
Changes `stack_compute_traces_parallel` to accept an optional `out` argument. This allows for us to optionally send the results to disk as we compute more. Should help us cutdown on memory usage in the "ROI and trace extraction" step if we need to.