### PR TITLE
Convert the traces array to nested lists for Bokeh

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1009,7 +1009,7 @@
         "\n",
         "\n",
         "trace_plot_height = block_size*mskimg.shape[1]\n",
-        "all_tr_srcs = ColumnDataSource(data=dict(traces=traces, colors_rgb=colors_rgb))\n",
+        "all_tr_srcs = ColumnDataSource(data=dict(traces=traces.tolist(), colors_rgb=colors_rgb))\n",
         "tr_srcs = ColumnDataSource(data=dict(times_sel=[], traces_sel=[], colors_sel=[]))\n",
         "plot_tr = bp.Figure(plot_width=trace_plot_width, plot_height=trace_plot_height, x_range=(0.0, float(traces.shape[1])), y_range=(float(traces.min()), float(traces.max())),\n",
         "                 tools=[\"pan\", \"box_zoom\", \"resize\", \"wheel_zoom\", \"save\", \"reset\"], title=\"ROI traces\")\n",


### PR DESCRIPTION
This explicitly converts the traces array to nested lists for the Bokeh graph. Up to this point Bokeh has been doing this for us explicitly. However, in Bokeh 0.12.4, a nice enhancement has been added to Bokeh that will convert all NumPy arrays to a special compact JSON object. This is a nice feature that we will want to leverage as much as possible. Some things will benefit from the for free like the background image. However, the traces needs to be converted back to a nested Array on the JavaScript end, which Bokeh does not do yet. We also don't have a way to handle this either. So for now we skip this enhancement when it comes to the traces by preserving the behavior in pre-0.12.4 versions in 0.12.4 by explicitly converting the traces array to nested Python lists.