### PR TITLE
Remove full prefix build directory

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -23,7 +23,7 @@ build:
           conda2 build nanshe_workflow.recipe
           mv .git/shallow-not .git/shallow || true
           rm -rf /opt/conda2/conda-bld/work/*
-          conda2 remove -y -n _build --all
+          conda2 remove -y -n _build --all || true
           conda2 remove -y -n _test --all
     - script:
         name: Build the Python 3 package and clean up after.
@@ -32,7 +32,7 @@ build:
           conda3 build nanshe_workflow.recipe
           mv .git/shallow-not .git/shallow || true
           rm -rf /opt/conda3/conda-bld/work/*
-          conda3 remove -y -n _build --all
+          conda3 remove -y -n _build --all || true
           conda3 remove -y -n _test --all
     - script:
         name: Install for Python 2 and clean up.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -25,7 +25,7 @@ build:
           rm -rf /opt/conda2/conda-bld/work/*
           conda2 remove -y -n _build --all || true
           conda2 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all
-          conda2 remove -y -n _test --all
+          conda2 remove -y -n _test --all || true
     - script:
         name: Build the Python 3 package and clean up after.
         code: |-
@@ -35,7 +35,7 @@ build:
           rm -rf /opt/conda3/conda-bld/work/*
           conda3 remove -y -n _build --all || true
           conda3 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all
-          conda3 remove -y -n _test --all
+          conda3 remove -y -n _test --all || true
     - script:
         name: Install for Python 2 and clean up.
         code: |-

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -24,6 +24,7 @@ build:
           mv .git/shallow-not .git/shallow || true
           rm -rf /opt/conda2/conda-bld/work/*
           conda2 remove -y -n _build --all || true
+          conda2 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all
           conda2 remove -y -n _test --all
     - script:
         name: Build the Python 3 package and clean up after.
@@ -33,6 +34,7 @@ build:
           mv .git/shallow-not .git/shallow || true
           rm -rf /opt/conda3/conda-bld/work/*
           conda3 remove -y -n _build --all || true
+          conda3 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all
           conda3 remove -y -n _test --all
     - script:
         name: Install for Python 2 and clean up.


### PR DESCRIPTION
At some point `conda-build` started using full prefix build directories just to be safe. This has broken our CI as we expected to be able to remove the short prefix name from before. This fixes it to remove the full prefix build directory. Once we move to `conda-build` version 2 this will be much easier as we can do `conda build purge` instead of individually cleaning up these directories.