### PR TITLE
Add a title to the Bokeh HTML plot

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -859,6 +859,8 @@
       },
       "outputs": [],
       "source": [
+        "import os\n",
+        "\n",
         "import numpy\n",
         "import numpy as np\n",
         "\n",
@@ -1071,7 +1073,7 @@
         "if os.path.exists(data_proj_html):\n",
         "    os.remove(data_proj_html)\n",
         "\n",
-        "bp.output_file(data_proj_html)\n",
+        "bp.output_file(data_proj_html, title=os.path.splitext(data_proj_html)[0])\n",
         "bp.save(plot_group)"
       ]
     },


### PR DESCRIPTION
The HTML document title was defaulting to "Bokeh Plot" before. While the file is uniquely named, it would be nice for the plot to have a uniquely specified title. This will make it easier to navigate between multiple different open plots in the browser.