### PR TITLE
Fix up conda-build cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ nanshe_workflow.egg-info/
 _builds/
 _projects/
 _steps/
+.wercker/
 
 # iPython checkpoints.
 .ipynb_checkpoints/

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -24,7 +24,7 @@ build:
           mv .git/shallow-not .git/shallow || true
           rm -rf /opt/conda2/conda-bld/work/*
           conda2 remove -y -n _build --all || true
-          conda2 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all
+          conda2 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all || true
           conda2 remove -y -n _test --all || true
     - script:
         name: Build the Python 3 package and clean up after.
@@ -34,7 +34,7 @@ build:
           mv .git/shallow-not .git/shallow || true
           rm -rf /opt/conda3/conda-bld/work/*
           conda3 remove -y -n _build --all || true
-          conda3 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all
+          conda3 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all || true
           conda3 remove -y -n _test --all || true
     - script:
         name: Install for Python 2 and clean up.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -25,6 +25,7 @@ build:
           rm -rf /opt/conda2/conda-bld/work/*
           conda2 remove -y -n _build --all || true
           conda2 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all || true
+          conda2 remove -y -n _b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold --all || true
           conda2 remove -y -n _test --all || true
     - script:
         name: Build the Python 3 package and clean up after.
@@ -35,6 +36,7 @@ build:
           rm -rf /opt/conda3/conda-bld/work/*
           conda3 remove -y -n _build --all || true
           conda3 remove -y -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all || true
+          conda3 remove -y -n _b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold --all || true
           conda3 remove -y -n _test --all || true
     - script:
         name: Install for Python 2 and clean up.


### PR DESCRIPTION
Fixes up how `conda-build` environments are cleaned up after each build. Makes sure each cleanup step can fail (per the new `conda` behavior) without failing the build.