### PR TITLE
Display the Bokeh HTML file in the notebook

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1109,10 +1109,6 @@
         "\n",
         "plot_group = HBox(*plot_projs)\n",
         "\n",
-        "if __IPYTHON__:\n",
-        "    bp.output_notebook()\n",
-        "    bp.show(plot_group)\n",
-        "\n",
         "\n",
         "# Clear out the old HTML file before writing a new one.\n",
         "if os.path.exists(data_proj_html):\n",
@@ -1162,7 +1158,12 @@
         "        fh.write(html_cont)\n",
         "\n",
         "script, div = be.components(plot_group)\n",
-        "write_html(data_proj_html, os.path.splitext(data_proj_html)[0], div, script)"
+        "write_html(data_proj_html, os.path.splitext(data_proj_html)[0], div, script)\n",
+        "\n",
+        "\n",
+        "if __IPYTHON__:\n",
+        "    from IPython.display import display, IFrame\n",
+        "    display(IFrame(data_proj_html, \"100%\", 1.05*proj_plot_height))"
       ]
     },
     {


### PR DESCRIPTION
Expands on PR ( https://github.com/nanshe-org/nanshe_workflow/pull/27 ).

Instead of displaying Bokeh's Notebook output, display the HTML file that we wrote out to disk in the Jupyter Notebook. This allows us to view the file as it was written and with any modifications that are relevant. This way things like other formatting changes that are out of the scope of Bokeh still show up. Also any dependencies that we add will also be available within the page. Overall this should also reduce the differences between what is displayed in the Jupyter Notebook and the HTML file that one views later.

We need to use an `iframe` when displaying the HTML instead of including the full HTML as Jupyter Notebooks do not handle the latter. This likely has to do with some formatting they do in the background to make sure it fits within the cell and the page overall. We have also found this is necessary to make sure external JavaScript dependencies work correctly (e.g. BokehJS and others). More details can be found in issue ( https://github.com/jupyter/notebook/issues/749 ).

The `iframe` is formatted to allow the width to expand to the full width of the cell (whatever that might be). The height is determined based on the plot size with an approximate formulation that should be sufficient for fitting both plots. In general, these settings should minimize the need for scrolling in the `iframe`. Particularly it should avoid scrolling in the vertical direction. Also it should make it easy to view the traces and ROIs in the same field of view given the default settings. However, scrolling within the `iframe` may still be necessary if the plots are resized.