### PR TITLE
Drop unused line in HTML file generation

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1120,7 +1120,6 @@
         "    return \"\\n\".join(imap(lambda l: spaces + l, text.splitlines()))\n",
         "\n",
         "def write_html(filename, title, div, script):\n",
-        "    indent(bokeh.resources.CDN.render(), 8)\n",
         "    html_tmplt = textwrap.dedent(u\"\"\"\\\n",
         "        <html lang=\"en\">\n",
         "            <head>\n",


### PR DESCRIPTION
Appears there was a stray line from testing that made it into the HTML file generation function in PR ( https://github.com/nanshe-org/nanshe_workflow/pull/27 ). Thus we cut this unused line here.