### PR TITLE
Update notebook metadata

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -204,7 +204,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": true
+        "collapsed": false
       },
       "outputs": [],
       "source": [

--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -4,7 +4,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -15,7 +17,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "# Specify input data\n",
         "\n",
@@ -31,7 +36,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -61,7 +68,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "# Configure and startup Cluster"
       ]
@@ -70,7 +80,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -91,7 +103,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -101,7 +115,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "# Define functions for computation."
       ]
@@ -110,7 +127,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -127,7 +146,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -181,7 +202,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -204,7 +227,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -243,14 +268,20 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "# Begin workflow. Set parameters and run each cell."
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### View Input Data\n",
         "\n",
@@ -261,7 +292,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -280,7 +313,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Projections\n",
         "\n",
@@ -291,7 +327,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -334,7 +372,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Subtract Projection\n",
         "\n",
@@ -346,7 +387,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -385,7 +428,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Background Subtraction\n",
         "\n",
@@ -406,7 +452,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -466,7 +514,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Wavelet Transform\n",
         "\n",
@@ -482,7 +533,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -528,7 +581,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Normalize Data\n",
         "* `block_frames` (`int`): number of frames to work with in each full frame block (run in parallel).\n",
@@ -539,7 +595,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -581,7 +639,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Dictionary Learning\n",
         "\n",
@@ -600,7 +661,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -657,7 +720,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Postprocessing\n",
         "\n",
@@ -677,7 +743,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -750,7 +818,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### ROI and trace extraction\n",
         "\n",
@@ -761,7 +832,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -839,7 +912,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "# End of workflow. Shutdown cluster."
       ]
@@ -848,7 +924,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -863,7 +941,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "# Prepare interactive projection graph"
       ]
@@ -872,7 +953,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -935,7 +1018,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -953,7 +1038,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      },
       "source": [
         "### Result visualization\n",
         "* `proj_img` (`str` or `list` of `str`): which projection or projections to plot (e.g. \"max\", \"mean\", \"std\").\n",
@@ -969,7 +1057,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true,
+        "scrolled": false
       },
       "outputs": [],
       "source": [
@@ -1172,7 +1263,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": [
@@ -1185,7 +1278,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": false
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
       },
       "outputs": [],
       "source": []


### PR DESCRIPTION
Using the newest version of the Jupyter Notebook. The `metadata` portions of each cell got a bit more info. This updates our copy to have these new metadata values too.