### PR TITLE
Seed initial dictionary per atom for all types

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -466,9 +466,9 @@ def block_generate_dictionary_parallel(client, calculate_block_shape, calculate_
 
                 def __iter__(self):
                     for each_data_block_dict_sample in self.data_blocks_dict_sample:
-                        if not isinstance(self.data, h5py.Dataset):
+                        try:
                             yield self.data[each_data_block_dict_sample]
-                        else:
+                        except TypeError:
                             each_data_block_dict = numpy.empty(
                                 (len(each_data_block_dict_sample[0]),) +
                                 len_slices(each_data_block_dict_sample[1:]),


### PR DESCRIPTION
Rewritten so as to handle NumPy, HDF5, Zarr, and LazyDataset cases. NumPy and LazyDataset are able to handle the slice without help in this case. HDF5 and Zarr are not, but both return a `TypeError` when they fail. So instead of trying to ask for permission we ask for forgiveness and handle the `TypeError` case specially.