### PR TITLE
Drop unneeded `h5py` import

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -11,7 +11,6 @@ from time import sleep
 
 from psutil import cpu_count
 
-import h5py
 import numpy
 
 from builtins import zip as izip


### PR DESCRIPTION
Realized that the `h5py` import in `nanshe_workflow.par` is no longer needed in light of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/40 ). So am clearing it out.