### PR TITLE
Normalize over `norm_frames` for viewer

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -421,8 +421,8 @@
         "    mplsv = plt.figure(FigureClass=MPLViewer)\n",
         "    mplsv.set_images(\n",
         "        result_image_stack,\n",
-        "        vmin=par_compute_min_projection(num_frames=block_frames)(result_image_stack).min(),\n",
-        "        vmax=par_compute_max_projection(num_frames=block_frames)(result_image_stack).max()\n",
+        "        vmin=par_compute_min_projection(num_frames=norm_frames)(result_image_stack).min(),\n",
+        "        vmax=par_compute_max_projection(num_frames=norm_frames)(result_image_stack).max()\n",
         "    )"
       ]
     },


### PR DESCRIPTION
Was normalizing over `block_frames` number of frames, but should be normalizing over `norm_frames` number of frames. So this fixes it to the correct value.