### PR TITLE
Use kenjutsu's new API

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - runipy
     - cloudpickle
     - imgroi
-    - kenjutsu
+    - kenjutsu >=0.3.0
     - metawrap
     - mplview
     - xnumpy

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -15,7 +15,8 @@ import numpy
 
 from builtins import zip as izip
 
-from kenjutsu.kenjutsu import len_slices, split_blocks
+from kenjutsu.measure import len_slices
+from kenjutsu.blocks import split_blocks
 
 from metawrap.metawrap import tied_call_args, unwrap
 


### PR DESCRIPTION
Make use of kenjutsu's new API and require a version recent enough so as to have it.