### PR TITLE
Make `out` in `norm_layer` optional

### DIFF
--- a/nanshe_workflow/proj.py
+++ b/nanshe_workflow/proj.py
@@ -446,7 +446,7 @@ def stack_norm_layer_parallel(client, num_frames):
             callable:             parallelized callable.
     """
 
-    def norm_layer(data, out):
+    def norm_layer(data, out=None):
         if out is None:
             out = numpy.empty(data.shape, data.dtype)
 


### PR DESCRIPTION
It appears that `out` was required for `norm_layer` even though we handle the possibility of it just being `None`. This changes the `out` parameter so that it defaults to `None` making it truly optional.