### PR TITLE
Require kenjutsu 0.5.0+

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - runipy
     - cloudpickle
     - imgroi
-    - kenjutsu >=0.3.0
+    - kenjutsu >=0.5.0
     - metawrap
     - mplview
     - xnumpy


### PR DESCRIPTION
Needed for `num_blocks` and `split_blocks` with `indices`. Unfortunately we were already using the latter in v2.0.7 with `ipyparallel` (even though it wasn't strictly necessary). So this just forces us to upgrade when installing.