### PR TITLE
Standardize on future iterables

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -142,7 +142,7 @@
         "\n",
         "    from contextlib import contextmanager\n",
         "\n",
-        "    from builtins import range\n",
+        "    from builtins import range as irange\n",
         "\n",
         "    import numpy\n",
         "    import scipy\n",

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -15,7 +15,10 @@ import zarr
 
 import kenjutsu.format
 
-from builtins import map
+from builtins import (
+    map as imap,
+    range as irange,
+)
 from past.builtins import unicode
 
 
@@ -247,7 +250,7 @@ class LazyZarrDataset(LazyDataset):
                     return(dataset[self.key][key].astype(self.dtype))
                 except TypeError:
                     ref_key = list()
-                    for i in range(len(self.key)):
+                    for i in irange(len(self.key)):
                         each_key = self.key[i]
                         try:
                             each_key = list(each_key)
@@ -259,7 +262,7 @@ class LazyZarrDataset(LazyDataset):
                     ref_key = kenjutsu.format.reformat_slices(ref_key, self.shape)
 
                     # Verify there is only one sequence
-                    num_seqs = sum(map(
+                    num_seqs = sum(imap(
                         lambda i: isinstance(i, collections.Sequence),
                         ref_key
                     ))

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -20,8 +20,11 @@ import zarr
 import dask
 import dask.array
 
-from builtins import map as imap
-from builtins import zip as izip
+from builtins import (
+    map as imap,
+    range as irange,
+    zip as izip,
+)
 
 from kenjutsu.measure import len_slices
 from kenjutsu.blocks import num_blocks, split_blocks
@@ -142,10 +145,10 @@ def concat_dask(dask_arr):
     n_blocks = dask_arr.shape
 
     result = dask_arr.copy()
-    for i in range(-1, -1 - len(n_blocks), -1):
+    for i in irange(-1, -1 - len(n_blocks), -1):
         result2 = result[..., 0]
         for j in itertools.product(*[
-                range(e) for e in n_blocks[:i]
+                irange(e) for e in n_blocks[:i]
             ]):
             result2[j] = dask.array.concatenate(
                 result[j].tolist(),


### PR DESCRIPTION
Make sure that we are leveraging Python 3 behavior as often as possible in Python 2 by importing from `future`. Also make sure to prefix all iterable forms from `builtins` with an `i`. This avoids warnings from code linters about masking the actual builtin name.