### PR TITLE
Support optional TIFF ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ registered_callables.py
 
 # Ignore any data.
 *.h5
+*.tif
+*.tiff
 *.zarr
 *_proj.html
 

--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -33,7 +33,7 @@
       "outputs": [],
       "source": [
         "data_dir = \"\"\n",
-        "data = \"reg.h5\"\n",
+        "data = \"reg.tif\"\n",
         "data_basename = \"reg\"\n",
         "dataset = \"images\"\n",
         "\n",
@@ -42,6 +42,7 @@
         "\n",
         "import os\n",
         "\n",
+        "data_ext = os.path.splitext(data)[1].lower()\n",
         "data_dir = os.path.abspath(data_dir)\n",
         "\n",
         "postfix_sub = \"_sub\"\n",
@@ -56,6 +57,7 @@
         "postfix_html = \"_proj\"\n",
         "\n",
         "h5_ext = os.path.extsep + \"h5\"\n",
+        "tiff_ext = os.path.extsep + \"tif\"\n",
         "zarr_ext = os.path.extsep + \"zarr\"\n",
         "html_ext = os.path.extsep + \"html\""
       ]
@@ -167,7 +169,7 @@
         "    from nanshe.imp.filters.wavelet import transform as wavelet_transform\n",
         "\n",
         "    import nanshe_workflow\n",
-        "    from nanshe_workflow.data import io_remove, zip_zarr, open_zarr, DataBlocks, LazyZarrDataset\n",
+        "    from nanshe_workflow.data import io_remove, dask_imread, zip_zarr, open_zarr, DataBlocks, LazyZarrDataset\n",
         "\n",
         "zarr.blosc.set_nthreads(1)\n",
         "zarr.blosc.use_threads = False\n",
@@ -257,7 +259,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Convert to Zarr"
+        "### Convert TIFF/HDF5 to Zarr"
       ]
     },
     {
@@ -266,20 +268,35 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Somehow we can't overwrite the file in the container so this is needed.\n",
-        "io_remove(data_basename + zarr_ext)\n",
+        "if data_ext == tiff_ext:\n",
+        "    a = dask_imread(data)\n",
         "\n",
-        "with open_zarr(data_basename + zarr_ext, \"w\") as f2:\n",
-        "    with h5py.File(data, \"r\") as f1:\n",
-        "        f2.create_dataset(\n",
+        "    io_remove(data_basename + zarr_ext)\n",
+        "    with open_zarr(data_basename + zarr_ext, \"w\") as f1:\n",
+        "        d = f1.create_dataset(\n",
         "            dataset,\n",
-        "            shape=f1[dataset].shape,\n",
-        "            dtype=f1[dataset].dtype,\n",
+        "            shape=a.shape,\n",
+        "            dtype=a.dtype,\n",
         "            chunks=True\n",
         "        )\n",
-        "        f2[dataset] = f1[dataset]\n",
+        "        a = a.rechunk(d.chunks)\n",
+        "        a.store(d)\n",
+        "        del d\n",
+        "    zip_zarr(data_basename + zarr_ext)\n",
         "\n",
-        "zip_zarr(data_basename + zarr_ext)"
+        "    del a\n",
+        "elif data_ext == h5_ext:\n",
+        "    io_remove(data_basename + zarr_ext)\n",
+        "    with open_zarr(data_basename + zarr_ext, \"w\") as f2:\n",
+        "        with h5py.File(data, \"r\") as f1:\n",
+        "            f2.create_dataset(\n",
+        "                dataset,\n",
+        "                shape=f1[dataset].shape,\n",
+        "                dtype=f1[dataset].dtype,\n",
+        "                chunks=True\n",
+        "            )\n",
+        "            f2[dataset] = f1[dataset]\n",
+        "    zip_zarr(data_basename + zarr_ext)"
       ]
     },
     {

--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - distributed
     - runipy
     - cloudpickle
+    - pims
     - imgroi
     - kenjutsu >=0.5.0
     - metawrap

--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - runipy
     - cloudpickle
     - pims
+    - tifffile
     - imgroi
     - kenjutsu >=0.5.0
     - metawrap

--- a/setup_tests.py
+++ b/setup_tests.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 import numpy
-import h5py
+import tifffile
 
 from builtins import range as irange
 
@@ -71,5 +71,6 @@ for i in irange(len(bases_images)):
 image_stack *= numpy.iinfo(numpy.uint16).max / image_stack.max()
 image_stack = image_stack.astype(numpy.uint16)
 
-with h5py.File("reg.h5", "w") as f:
-    f["images"] = image_stack
+with tifffile.TiffWriter("reg.tif", bigtiff=True) as f:
+    for i in irange(len(image_stack)):
+        f.save(image_stack[i])

--- a/teardown_tests.py
+++ b/teardown_tests.py
@@ -10,6 +10,7 @@ if not os.environ.get("TEST_NOTEBOOKS"):
     sys.exit(0)
 
 for each in list(sys.argv[1:]) + [
+    "reg.tif",
     "reg.h5",
     "reg_sub.h5",
     "reg_f_f0.h5",


### PR DESCRIPTION
If the user provides a TIFF file or regex matching many TIFF files, use the wonderful [PIMS]( http://soft-matter.github.io/pims ) library to inspect metadata (i.e. `shape` and `dtype`) useful for loading image data into Dask Arrays via Dask Delayed. Also use PIMS to handle reading individual frames from the TIFF files with Dask as needed. If there are multiple TIFFs, concatenate them along the 0th axis (the same one used for frames). For now, we simply leverage this framework to convert the TIFF stacks into one large Zarr file.

If the user provides an HDF5 file, conversion proceeds to Zarr as before. Detection of the HDF5 file happens automatically before performing conversion. No flags are necessary to specify this. Thus working with HDF5 data behaves exactly the same as before.

This allows us to easily work with this data as we otherwise would. Also saves us from bifurcating the workflow to data handling as we already use , but simply removes the need for an independent conversion step outside the workflow. Thus making it easier to play with data in one place and making it easier for users to get started.