### PR TITLE
Repeatedly chdir until successful

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -94,8 +94,9 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "os.chdir(data_dir)\n",
-        "client[:].apply(os.chdir, os.getcwd()).get();"
+        "while not all(map(lambda p: p == data_dir, [os.getcwd()] + client[:].apply(os.getcwd).get())):\n",
+        "    os.chdir(data_dir)\n",
+        "    client[:].apply(os.chdir, os.getcwd()).get()"
       ]
     },
     {


### PR DESCRIPTION
As getting all of the engines switched to the same directory seems to be an issue on the cluster sometimes, repeatedly switch directories until all engines and the client note that they are using the same directory. This way we can make sure any stragglers are taken care of.