### PR TITLE
Optionally use pyFFTW

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -220,8 +220,13 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from dask.array.fft import fftn\n",
-        "from dask.array.fft import ifftn"
+        "try:\n",
+        "    import pyfftw.interfaces.numpy_fft as numpy_fft\n",
+        "except ImportError:\n",
+        "    import numpy.fft as numpy_fft\n",
+        "\n",
+        "fftn = da.fft.fft_wrap(numpy_fft.fftn)\n",
+        "ifftn = da.fft.fft_wrap(numpy_fft.ifftn)"
       ]
     },
     {


### PR DESCRIPTION
Make use of pyFFTW with Dask if it is available. If not, fallback to using NumPy's FFT package with Dask instead. This is made optional as pyFFTW links to FFTW, which is under the GPL2 license. So will not be included by default.