### PR TITLE
Fix cleanup of ipyparallel's Distributed cluster

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -138,7 +138,7 @@ def get_executor(client):
     try:
         yield executor
     finally:
-        executor.shutdown()
+        client.stop_dask()
 
 
 def map_dask(client, calculate_block, data, block_shape, block_halo, blocks=True):


### PR DESCRIPTION
When bootstrapping the Distributed cluster on top of the existing ipyparallel cluster using `become_dask`, one should not run `shutdown` on the Distributed instance, but instead run `stop_dask`. It seems if one doesn't run `stop_dask` then Distributed gets some weird messages about the resources available on the cluster. Namely that the number of cores is increasing. Running `stop_dask` fixes that issue. It may also address other issues that we have seen with memory usage in our registration prototype.