### PR TITLE
Explicitly shutdown the Distributed executor

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -138,6 +138,7 @@ def get_executor(client):
     try:
         yield executor
     finally:
+        executor.shutdown()
         client.stop_dask()
 
 


### PR DESCRIPTION
Make sure to shutdown the Distributed executor first before calling `stop_dask` on the ipyparallel client. Otherwise we get a concerning warning.

xref: https://github.com/ipython/ipyparallel/issues/265