### PR TITLE
Drop mock from requirements

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -39,8 +39,6 @@ requirements:
     - xnumpy
     - yail
     - zarr
-    # Testing
-    - mock
 
 about:
   home: {{ data.get("url") }}


### PR DESCRIPTION
As `mock` is not being used anywhere, it makes more sense to just drop it.