### PR TITLE
Rechunk denoising's smoothed FFT to match input

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -401,7 +401,7 @@
         "            da_imgs_medf_fft, (0,) + (da_imgs_medf_fft.ndim - 1) * (norm_filt_sigma,)\n",
         "        )\n",
         "        da_imgs_fft_smoothed = da_imgs_fft_smoothed.rechunk(\n",
-        "            (1,) + da_imgs_fft_smoothed.shape[1:]\n",
+        "            da_imgs_medf_fft.chunks\n",
         "        )\n",
         "        da_imgs_fft_filt = da_imgs_medf_fft - da_imgs_fft_smoothed\n",
         "\n",


### PR DESCRIPTION
Instead of rechunking the smoothed FFT to have a single frame and full shape specifically. Simply rechunk the smoothed FFT to have the same chunks as its input data has. This seems to be important on larger data where doing a full rechunking from scratch eats up a fair bit of time both in graph construction and computation. By doing this instead, we merely fuse the chunks along the shape dimensions, which seems to be much faster on large data.