### PR TITLE
Use `map` to run `chdir` on workers

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -95,9 +95,17 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "while not all(map(lambda p: p == data_dir, [os.getcwd()] + client[:].apply(os.getcwd).get())):\n",
+        "from builtins import range as irange\n",
+        "\n",
+        "def getcwdi(i):\n",
+        "    from os import getcwd\n",
+        "    return getcwd()\n",
+        "\n",
+        "while not all(map(lambda p: p == data_dir, [os.getcwd()] + client[:].map(getcwdi, irange(len(client))).get())):\n",
         "    os.chdir(data_dir)\n",
-        "    client[:].apply(os.chdir, os.getcwd()).get()"
+        "    client[:].map(os.chdir, len(client) * [data_dir]).get()\n",
+        "\n",
+        "del getcwdi"
       ]
     },
     {


### PR DESCRIPTION
To make sure that all workers change to the data directory, use `map` and sequences that are of the length of the number of workers. This is done to make sure all of them change and not just some of them. Also have workers change to the data directory not just the current directory of the client (even though these should be the same).