### PR TITLE
Add num frames per block parameter to denoising

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -366,6 +366,7 @@
         "* `norm_filt_sigma` (`int`/`float`): sigma for Gaussian filter\n",
         "\n",
         "<br>\n",
+        "* `block_frames` (`int`): number of frames to work with in each block (run in parallel).\n",
         "* `norm_frames` (`int`): number of frames for use during normalization of each full frame block (run in parallel)."
       ]
     },
@@ -381,6 +382,7 @@
         "med_filt_size = 3\n",
         "norm_filt_sigma = 100\n",
         "\n",
+        "block_frames = 100\n",
         "norm_frames = 100\n",
         "\n",
         "\n",
@@ -393,7 +395,7 @@
         "    with get_executor(client) as executor:\n",
         "        # Load and prep data for computation.\n",
         "        imgs = f[\"images\"]\n",
-        "        da_imgs = da.from_array(imgs, chunks=(1,) + imgs.shape[1:])\n",
+        "        da_imgs = da.from_array(imgs, chunks=(block_frames,) + imgs.shape[1:])\n",
         "\n",
         "        da_imgs = da_imgs[1:-1]\n",
         "\n",

--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -363,7 +363,10 @@
         "### Denoising\n",
         "\n",
         "* `med_filt_size` (`int`): footprint size for median filter\n",
-        "* `norm_filt_sigma` (`int`/`float`): sigma for Gaussian filter"
+        "* `norm_filt_sigma` (`int`/`float`): sigma for Gaussian filter\n",
+        "\n",
+        "<br>\n",
+        "* `norm_frames` (`int`): number of frames for use during normalization of each full frame block (run in parallel)."
       ]
     },
     {


### PR DESCRIPTION
Includes a number of frames per block parameter for the denoising step. This should cause Dask to load in multiple frames at once and compute over each block of frames. Should allow the user to play with this parameter to effect how much data is loaded, how much memory is used per job, and how many times IO needs to be performed.