### PR TITLE
Refactor out ipyparallel profile name

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -78,15 +78,17 @@
       "source": [
         "from nanshe_workflow.par import cleanup_cluster_files, get_client, set_num_workers\n",
         "\n",
+        "ipypar_prof = \"sge\"\n",
+        "\n",
         "num_workers = set_num_workers(num_workers)\n",
         "\n",
-        "cleanup_cluster_files(\"sge\")\n",
+        "cleanup_cluster_files(ipypar_prof)\n",
         "\n",
         "from sys import executable as PYTHON\n",
-        "!$PYTHON -m ipyparallel.apps.ipclusterapp start --daemon --profile=sge\n",
+        "!$PYTHON -m ipyparallel.apps.ipclusterapp start --daemon --profile=$ipypar_prof\n",
         "del PYTHON\n",
         "\n",
-        "client = get_client(\"sge\")"
+        "client = get_client(ipypar_prof)"
       ]
     },
     {
@@ -1105,11 +1107,13 @@
       "source": [
         "from nanshe_workflow.par import cleanup_cluster_files\n",
         "\n",
+        "ipypar_prof = \"sge\"\n",
+        "\n",
         "from sys import executable as PYTHON\n",
-        "!$PYTHON -m ipyparallel.apps.ipclusterapp stop --profile=sge\n",
+        "!$PYTHON -m ipyparallel.apps.ipclusterapp stop --profile=$ipypar_prof\n",
         "del PYTHON\n",
         "\n",
-        "cleanup_cluster_files(\"sge\")"
+        "cleanup_cluster_files(ipypar_prof)"
       ]
     },
     {


### PR DESCRIPTION
Instead of having to change the profile name in multiple locations, this should allow for us changing it in two. So should cause less issues selecting the right profile to use starting or shutting down the cluster.