### PR TITLE
Switch workflow from Python 2 to Python 3

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1783,21 +1783,21 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 2",
+      "display_name": "Python 3",
       "language": "python",
-      "name": "python2"
+      "name": "python3"
     },
     "language_info": {
       "codemirror_mode": {
         "name": "ipython",
-        "version": 2
+        "version": 3
       },
       "file_extension": ".py",
       "mimetype": "text/x-python",
       "name": "python",
       "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython2",
-      "version": "2.7.13"
+      "pygments_lexer": "ipython3",
+      "version": "3.6.2"
     },
     "widgets": {
       "state": {},


### PR DESCRIPTION
Users can still make use of Python 2 if they want. However it just makes sense at this point to use Python 3. It is newer, has many nice features, and newer, more performant versions of our dependencies. Given everything we need can be installed on Python 3 (even optional dependencies), this is just the right way to go.