### PR TITLE
Avoid using repeat in trace computation

### DIFF
--- a/nanshe_workflow/proj2.py
+++ b/nanshe_workflow/proj2.py
@@ -26,10 +26,7 @@ def compute_traces(imagestack, rois):
     if not issubclass(imagestack.real.dtype.type, numpy.floating):
         imagestack = imagestack.astype(float)
 
-    traces = (
-        rois[:, None].repeat(len(imagestack), axis=1) *
-        imagestack[None].repeat(len(rois), axis=0)
-    )
+    traces = rois[:, None] * imagestack[None]
     traces = (
         traces.sum(axis=tuple(range(2, traces.ndim))) /
         rois.sum(axis=tuple(range(1, rois.ndim)))[:, None]


### PR DESCRIPTION
As Dask should be able to broadcast these arrays without issues, simply take advantage of that feature instead of manually repeating them. This should avoid some rechunking that appears to be causing a slow down in the computation.