### PR TITLE
Add artificial boundary in test data

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1315,7 +1315,7 @@
         "\n",
         "significance_threshold = 3.0\n",
         "wavelet_scale = 3\n",
-        "noise_threshold = 2.0\n",
+        "noise_threshold = 3.0\n",
         "percentage_pixels_below_max = 0.8\n",
         "min_local_max_distance = 16.0\n",
         "\n",

--- a/setup_tests.py
+++ b/setup_tests.py
@@ -71,6 +71,11 @@ for i in irange(len(bases_images)):
 image_stack *= numpy.iinfo(numpy.uint16).max / image_stack.max()
 image_stack = image_stack.astype(numpy.uint16)
 
+image_stack[:, :5, :] = 50000
+image_stack[:, -5:, :] = 50000
+image_stack[:, :, :5] = 50000
+image_stack[:, :, -5:] = 50000
+
 with tifffile.TiffWriter("data.tif", bigtiff=True) as f:
     for i in irange(len(image_stack)):
         f.save(image_stack[i])


### PR DESCRIPTION
To allow registration to run on the test data, but block any real changes, add an artificial boundary to the test data. This provides something that registration will be strongly encouraged to match. However it will be removed as soon as background subtraction occurs. So it doesn't really factor into later analysis. This way we can be confident registration is working ok on the test data and in CI runs.