### PR TITLE
Drop generating the nbconvert config in CI

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -72,6 +72,7 @@ build:
           echo -e "import os\n\n\nc = get_config()\n\nc.IPClusterStart.controller_launcher_class = \"SGE\"\nc.IPClusterEngines.engine_launcher_class = \"SGE\"\nc.IPClusterEngines.n = int(os.environ[\"CORES\"]) - 1" > /root/.ipython/profile_sge/ipcluster_config.py
           echo -e "c = get_config()\n\nc.HubFactory.ip = '*'\nc.HubFactory.engine_ip = '*'\nc.HubFactory.db_class = \"SQLiteDB\"" > /root/.ipython/profile_sge/ipcontroller_config.py
           echo -e "c = get_config()\n\nc.IPEngineApp.wait_for_url_file = 60\nc.EngineFactory.timeout = 60" > /root/.ipython/profile_sge/ipengine_config.py
+          mkdir -p /root/.jupyter
           echo -e "c = get_config()\n\nc.ExecutePreprocessor.timeout = 240" > /root/.jupyter/jupyter_nbconvert_config.py
     - script:
         name: Test notebook(s) on Python 2.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -72,7 +72,6 @@ build:
           echo -e "import os\n\n\nc = get_config()\n\nc.IPClusterStart.controller_launcher_class = \"SGE\"\nc.IPClusterEngines.engine_launcher_class = \"SGE\"\nc.IPClusterEngines.n = int(os.environ[\"CORES\"]) - 1" > /root/.ipython/profile_sge/ipcluster_config.py
           echo -e "c = get_config()\n\nc.HubFactory.ip = '*'\nc.HubFactory.engine_ip = '*'\nc.HubFactory.db_class = \"SQLiteDB\"" > /root/.ipython/profile_sge/ipcontroller_config.py
           echo -e "c = get_config()\n\nc.IPEngineApp.wait_for_url_file = 60\nc.EngineFactory.timeout = 60" > /root/.ipython/profile_sge/ipengine_config.py
-          jupyter nbconvert --generate-config
           echo -e "c = get_config()\n\nc.ExecutePreprocessor.timeout = 240" > /root/.jupyter/jupyter_nbconvert_config.py
     - script:
         name: Test notebook(s) on Python 2.


### PR DESCRIPTION
It seems something is getting messed up when trying to generate the default nbconvert configuration file due to some Unicode to ASCII conversion issues. So drop the call to `jupyter nbconvert --generate-config`. Then create the `.jupyter` directory and fill out the configuration content separately.