### PR TITLE
Add blank line after doc titles

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1137,6 +1137,7 @@
       "metadata": {},
       "source": [
         "### Normalize Data\n",
+        "\n",
         "* `block_frames` (`int`): number of frames to work with in each full frame block (run in parallel).\n",
         "* `norm_frames` (`int`): number of frames for use during normalization of each full frame block (run in parallel)."
       ]
@@ -1619,6 +1620,7 @@
       "metadata": {},
       "source": [
         "### Result visualization\n",
+        "\n",
         "* `proj_img` (`str` or `list` of `str`): which projection or projections to plot (e.g. \"max\", \"mean\", \"std\").\n",
         "* `block_size` (`int`): size of each point on any dimension in the image in terms of pixels.\n",
         "* `roi_alpha` (`float`): transparency of the ROIs in a range of [0.0, 1.0].\n",


### PR DESCRIPTION
This ends up happening with the way Jupyter Notebook's display markdown. Still this makes the code a little cleaner.