### PR TITLE
Use dask-core

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - notebook
     - ipyparallel
     - ipywidgets
-    - dask
+    - dask-core
     - distributed
     - dask-imread
     - dask-ndfilters

--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - setuptools
   run:
     - python
+    - numpy
     - psutil
     - nanshe >=0.1.0a54
     - bokeh >=0.12.4


### PR DESCRIPTION
Lighten up requirements by depending on `dask-core` instead of `dask`. As we don't need all of the things that `dask` pulls in and `dask-core` can easily be combined with the few things we need, it makes more sense to require `dask-core` instead. Also make `numpy` an explicit requirement.