### PR TITLE
Require toolz for dask array

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - ipyparallel
     - ipywidgets
     - dask-core
+    - toolz >=0.7.3
     - distributed
     - dask-imread
     - dask-ndfilters


### PR DESCRIPTION
One of the dependencies for `dask[array]` support is `toolz`. So this adds `toolz` as an explicit dependency now that `dask` is not one. Though `toolz` gets pulled in indirectly with `yail` as well, it makes sense to be explicit about this one.