### PR TITLE
Add blocks space parameter to normalization step

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1139,6 +1139,7 @@
         "### Normalize Data\n",
         "\n",
         "* `block_frames` (`int`): number of frames to work with in each full frame block (run in parallel).\n",
+        "* `block_space` (`int`): extent of each spatial dimension for each block (run in parallel).\n",
         "* `norm_frames` (`int`): number of frames for use during normalization of each full frame block (run in parallel)."
       ]
     },
@@ -1152,6 +1153,7 @@
         "\n",
         "\n",
         "block_frames = 40\n",
+        "block_space = 300\n",
         "norm_frames = 100\n",
         "\n",
         "\n",


### PR DESCRIPTION
The `block_space` parameter was being used in the data normalization step.  However it was not being set in that step. Instead it was being carried over from a previous computational step. This adds `block_space` as a parameter for the normalization step and documents it as one. Should make things a bit clearer.