### PR TITLE
Update the location of tini on Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,6 +1,6 @@
 box:
   id: nanshe/nanshe_notebook
-  entrypoint: /usr/bin/tini -- /usr/share/docker/entrypoint.sh
+  entrypoint: /opt/conda/bin/tini -- /usr/share/docker/entrypoint.sh
 
 build:
   steps:


### PR DESCRIPTION
We have switched to using `tini` from conda-forge. So update the path to `tini` accordingly.