### PR TITLE
Require jupyter_contrib_nbextensions

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - notebook
     - ipyparallel
     - ipywidgets
+    - jupyter_contrib_nbextensions
     - dask-core
     - toolz >=0.7.3
     - distributed


### PR DESCRIPTION
We need `jupyter_contrib_nbextensions` so that we can use the ExecuteTime extension. This is useful as it provides a timestamp for each cell and notes the run time. The former is useful when trying to line up events with other log information (e.g. from a cluster this runs on). The latter we already try to get by using the `%%time` magic. However using the ExecuteTime extension will present this information in a nicer way and make it easier to parse after the fact.