### PR TITLE
Drop cells' time magics

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -369,9 +369,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "front = 0\n",
         "back = 0\n",
         "\n",
@@ -440,9 +437,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "med_filt_size = 3\n",
         "norm_filt_sigma = 10\n",
         "\n",
@@ -548,9 +542,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "num_reps = 5\n",
         "tmpl_hist_wght = 0.25\n",
         "thld_rel_dist = 0.0\n",
@@ -769,9 +760,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "block_frames = 100\n",
         "\n",
         "\n",
@@ -869,9 +857,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "block_frames = 100\n",
         "norm_frames = 100\n",
         "\n",
@@ -951,9 +936,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "half_window_size = 100\n",
         "which_quantile = 0.5\n",
         "temporal_smoothing_gaussian_filter_stdev = 0.0\n",
@@ -1044,9 +1026,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "scale = 3\n",
         "\n",
         "block_frames = 200\n",
@@ -1121,9 +1100,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "block_frames = 40\n",
         "block_space = 300\n",
         "norm_frames = 100\n",
@@ -1206,9 +1182,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "n_components = 50\n",
         "batchsize = 256\n",
         "iters = 100\n",
@@ -1284,9 +1257,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "significance_threshold = 3.0\n",
         "wavelet_scale = 3\n",
         "noise_threshold = 3.0\n",
@@ -1375,9 +1345,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%time\n",
-        "\n",
-        "\n",
         "block_frames = 100\n",
         "\n",
         "\n",


### PR DESCRIPTION
Now that Jupyter contribs' extension ExecuteTime is in use in the workflow. Simply drop the use of `%%time` magics from the workflow as ExecuteTime already measures the run time of each step. Also ExecuteTime is a bit cleaner than `%%time` when it comes to debugging errors, which should help.