### PR TITLE
Flush after writing each Zarr ZipStore entry

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -118,9 +118,13 @@ def zip_zarr(name):
 
     io_remove(name_z)
 
-    with zarr.ZipStore(name_z, mode="w", compression=0, allowZip64=True) as f1:
+    # Opening in append mode to workaround a bug in `flush`.
+    # xref: https://github.com/alimanfoo/zarr/issues/158
+    with zarr.ZipStore(name_z, mode="a", compression=0, allowZip64=True) as f1:
         with open_zarr(name, "r") as f2:
-            f1.update(f2.store)
+            for k in f2.store.keys():
+                f1[k] = f2.store[k]
+                f1.flush()
 
     io_remove(name)
     shutil.move(name_z, name)


### PR DESCRIPTION
Instead of using the `MutableMapping` provided `update` method, use `keys` to iteratively retrieve/read each entry from the other Zarr (presumably a `DirectoryStore`) and copy them one-by-one to the `ZipStore`. Admittedly this does what `update` would have done underneath the hood. So performance should end up being the same at this point.

However we deviate by flushing after writing each entry to the `ZipStore`. Within Zarr, this amounts to closing and reopening the `ZipFile` object. This should guarantee that we only hold one entry in memory before writing it to disk. As there are no other references held to this entry, its reference count should drop to 0 after closing the `ZipFile` object. Thus triggering the entries removal from the Python interpreter's memory. As each entry should reasonably fit in memory (per design), handling one entry at a time should be completely doable.

Generally this should help keep our memory usage under control while converting each Zarr to the Zip-based format. Though there may be some penalty associated with flushing each entry (particularly on NFS). So we may need to come back and play with how many entries we write before flushing. For now we stick to just flushing after writing each entry to keep things simple.