### PR TITLE
Use `ZipStore` directly for Zarr conversion

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -115,6 +115,7 @@ def open_zarr(name, mode="r"):
 def zip_zarr(name):
     zip_ext = os.extsep + "zip"
 
+    io_remove(name + zip_ext)
     with zipfile.ZipFile(name + zip_ext, "w"):
         pass
 

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -114,17 +114,18 @@ def open_zarr(name, mode="r"):
 
 def zip_zarr(name):
     zip_ext = os.extsep + "zip"
+    name_z = name + zip_ext
 
-    io_remove(name + zip_ext)
-    with zipfile.ZipFile(name + zip_ext, "w"):
+    io_remove(name_z)
+    with zipfile.ZipFile(name_z, "w"):
         pass
 
-    with open_zarr(name + zip_ext, "w") as f1:
+    with open_zarr(name_z, "w") as f1:
         with open_zarr(name, "r") as f2:
             f1.store.update(f2.store)
 
     io_remove(name)
-    shutil.move(name + zip_ext, name)
+    shutil.move(name_z, name)
 
 
 def hdf5_to_zarr(hdf5_file, zarr_file):

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -117,12 +117,10 @@ def zip_zarr(name):
     name_z = name + zip_ext
 
     io_remove(name_z)
-    with zipfile.ZipFile(name_z, "w"):
-        pass
 
-    with open_zarr(name_z, "w") as f1:
+    with zarr.ZipStore(name_z, mode="w", compression=0, allowZip64=True) as f1:
         with open_zarr(name, "r") as f2:
-            f1.store.update(f2.store)
+            f1.update(f2.store)
 
     io_remove(name)
     shutil.move(name_z, name)


### PR DESCRIPTION
When converting a Zarr to a `ZipStore`-backed Zarr, simply use `ZipStore` directly to create and copy over the Zarr instead of using `open_group`. This avoids creating `.zattrs` and `.zgroup` to start with. Thus it avoids warnings about duplicate entries when copying over the Zarr into the Zip file. Admittedly unzipping the Zarr would have replaced these old entries by the newer ones. Still it is better to avoid this issue entirely since it is possible. Based on a little playing around, the resulting Zarr Zip files seem to work otherwise the same as they did before this change.