### PR TITLE
Revert "Flush after writing each Zarr ZipStore entry"

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -118,13 +118,9 @@ def zip_zarr(name):
 
     io_remove(name_z)
 
-    # Opening in append mode to workaround a bug in `flush`.
-    # xref: https://github.com/alimanfoo/zarr/issues/158
-    with zarr.ZipStore(name_z, mode="a", compression=0, allowZip64=True) as f1:
+    with zarr.ZipStore(name_z, mode="w", compression=0, allowZip64=True) as f1:
         with open_zarr(name, "r") as f2:
-            for k in f2.store.keys():
-                f1[k] = f2.store[k]
-                f1.flush()
+            f1.update(f2.store)
 
     io_remove(name)
     shutil.move(name_z, name)


### PR DESCRIPTION
Reverts PR ( https://github.com/nanshe-org/nanshe_workflow/pull/129 )

This reverts commit a450c82642a2d80574b73ad78e07ef725a2dfdfe as it was found that flushing after each entry was way too slow. Remains unclear whether this would help with the one off memory issue that we saw. Based on looking at the CPython codebase, it seems each value is written out immediately and locking is done around the Zip file (as parallel writing is not supported/unsafe). So it seems unlikely that this could have caused the issue anyways.

Given the performance issues and unclear benefits, flushing after each entry doesn't seem like a penalty that is necessary to take without more evidence. As such the codebase is being returned to a state where the `MutableMapping` method `update` is used instead. This should return the nice performance that was seen previously.