### PR TITLE
Add and use directory zipping function

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -44,6 +44,27 @@ def io_remove(name):
         raise ValueError("Unable to remove path, '%s'." % name)
 
 
+def zip_dir(dirname, compression=zipfile.ZIP_STORED, allowZip64=True):
+    dirname = os.path.abspath(dirname)
+    zipname = dirname + os.extsep + "zip"
+
+    if os.path.exists(zipname):
+        os.remove(zipname)
+
+    with zipfile.ZipFile(zipname,
+                         mode="w",
+                         compression=compression,
+                         allowZip64=allowZip64) as fh:
+        for path, dnames, fnames in os.walk(dirname):
+            fnames = sorted(fnames)
+            for each_fname in fnames:
+                each_fname = os.path.join(path, each_fname)
+                each_fname_rel = os.path.relpath(each_fname, dirname)
+                fh.write(each_fname, each_fname_rel)
+
+    return zipname
+
+
 def concat_dask(dask_arr):
     n_blocks = dask_arr.shape
 

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -134,15 +134,7 @@ def open_zarr(name, mode="r"):
 
 
 def zip_zarr(name):
-    zip_ext = os.extsep + "zip"
-    name_z = name + zip_ext
-
-    io_remove(name_z)
-
-    with zarr.ZipStore(name_z, mode="w", compression=0, allowZip64=True) as f1:
-        with open_zarr(name, "r") as f2:
-            f1.update(f2.store)
-
+    name_z = zip_dir(name)
     io_remove(name)
     shutil.move(name_z, name)
 


### PR DESCRIPTION
Implements a directory zipping function, `zip_dir`, to zip all contents underneath a specified directory and return the Zip file's location and name. Ignores all empty directories in the process. By doing this, we are able to guarantee that files from the directory tree are copied over into the Zip file in fixed block sizes (or smaller). This should help limit the amount of memory spent adding files into Zip.

Then updates `zip_zarr` to make use of `zip_dir` instead of using Zarr objects. Doing this should allow us to carry over the same memory guarantees that `zip_dir` makes to compressing Zarrs in `DirectoryStore`s. Hopefully this solves some memory issues on the cluster without incurring too much of a penalty on speed of Zip file construction.