### PR TITLE
Fix finding frame shifts

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -593,7 +593,7 @@
         "            shifted_frames = []\n",
         "            for j in irange(len(da_imgs_fft)):\n",
         "                shifted_frames.append(dask_ndfourier.fourier_shift(\n",
-        "                    da_imgs_fft[i], shifts[i]\n",
+        "                    da_imgs_fft[j], shifts[j]\n",
         "                ))\n",
         "            shifted_frames = da.stack(shifted_frames)\n",
         "\n",


### PR DESCRIPTION
Appears that the wrong indices were used to determine the shifted frames. This switches the index to correctly match the `for`-loop used to iterate over each frame and apply each shift.