### PR TITLE
Require `nbconvert`

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - bokeh >=0.12.4
     - future
     - webcolors
+    - nbconvert
     - notebook
     - ipyparallel
     - ipywidgets


### PR DESCRIPTION
Currently we are using `nbconvert` for testing and batch running of the workflow. While `nbconvert` was an implicit dependency due to `runipy` being a workflow dependency that needed it, something that is being directly used in the workflow like `nbconvert` should be explicitly made a dependency lest `runipy`'s dependencies change (or our dependence on it). Hence `nbconvert` is added as a dependency of the workflow.