### PR TITLE
Drop `runipy`

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - dask-imread
     - dask-ndfilters
     - dask-ndfourier
-    - runipy
     - cloudpickle
     - tifffile
     - imgroi


### PR DESCRIPTION
As we are now using `nbconvert` for batch runs and testing, we no longer need `runipy` as a requirement. Hence drop it from the install requirements.