### PR TITLE
Use `scandir`'s `walk`

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - setuptools
   run:
     - python
+    - scandir
     - numpy
     - psutil
     - nanshe >=0.1.0a54

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -11,6 +11,8 @@ import os
 import shutil
 import zipfile
 
+import scandir
+
 import h5py
 import numpy
 import tifffile
@@ -55,7 +57,7 @@ def zip_dir(dirname, compression=zipfile.ZIP_STORED, allowZip64=True):
                          mode="w",
                          compression=compression,
                          allowZip64=allowZip64) as fh:
-        for path, dnames, fnames in os.walk(dirname):
+        for path, dnames, fnames in scandir.walk(dirname):
             fnames = sorted(fnames)
             for each_fname in fnames:
                 each_fname = os.path.join(path, each_fname)


### PR DESCRIPTION
Instead of using `os.walk`, use `scandir.walk` for better performance on Python 2. As we are currently using Python 3.6, this has no impact on that Python version since its `os.walk` implementation is the same as `scandir.walk`'s. Though if we have to go back to Python 2 because of some dependency, this should make sure the performance does not suffer in this area.