### PR TITLE
More robust parallel directory and file removal

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -203,12 +203,15 @@ def open_zarr(name, mode="r"):
 def zip_zarr(name, executor=None):
     name_z = zip_dir(name)
 
-    if executor is None:
-        io_remove(name)
-    else:
-        dask_io_remove(name, executor=executor)
+    name_rm = os.extsep + name
+    os.rename(name, name_rm)
 
     shutil.move(name_z, name)
+
+    if executor is None:
+        io_remove(name_rm)
+    else:
+        dask_io_remove(name_rm, executor=executor)
 
 
 def hdf5_to_zarr(hdf5_file, zarr_file):

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -81,6 +81,8 @@ def dask_rm_tree(dirname):
 
 
 def dask_io_remove(name, executor=None):
+    name = os.path.abspath(name)
+
     rm_task = None
     if not os.path.exists(name):
         rm_task = dask_rm_nothing()

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -88,8 +88,10 @@ def dask_io_remove(name, executor=None):
         rm_task = dask_rm_nothing()
     elif os.path.isfile(name):
         rm_task = dask_rm_file(name)
+        rm_task = dask.delayed(io_remove)(rm_task)
     elif os.path.isdir(name):
         rm_task = dask_rm_tree(name)
+        rm_task = dask.delayed(io_remove)(rm_task)
     else:
         raise ValueError("Unable to remove path, '%s'." % name)
 

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -59,7 +59,7 @@ def dask_rm_file(fname):
 
 @dask.delayed
 def dask_rm_dir(dname, *deps):
-    os.rmdir(dname)
+    shutil.rmtree(dname)
     return dname
 
 

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -4,6 +4,7 @@ __date__ = "$Nov 05, 2015 13:54$"
 
 import collections
 from contextlib import contextmanager
+import errno
 import itertools
 import glob
 import numbers
@@ -53,13 +54,21 @@ def dask_rm_nothing():
 
 @dask.delayed
 def dask_rm_file(fname):
-    os.remove(fname)
+    try:
+        os.remove(fname)
+    except IOError as e:
+        if e.errno != errno.ENOENT:
+            raise
     return fname
 
 
 @dask.delayed
 def dask_rm_dir(dname, *deps):
-    shutil.rmtree(dname)
+    try:
+        shutil.rmtree(dname)
+    except IOError as e:
+        if e.errno != errno.ENOENT:
+            raise
     return dname
 
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/nanshe-org/nanshe_workflow/pull/145 ).

Makes some adjustments to the parallel directory and file removal strategy added in PR ( https://github.com/nanshe-org/nanshe_workflow/pull/145 ). This should make it work a bit smoother on NFS should it be needed. Improves the robustness of removal in two ways. First handles the case where directories and/or files may not have been fully cleaned up in a step or at the end by cleaning them up in the task or taking a second serial pass at the end. Second handles the case that the file or directory to remove is already gone and suppress the corresponding error when it pops up (though re-raises all other errors). Through this combination, the parallel removal process should be more robust to NFS being slow and make sure that the removal is completed regardless.