### PR TITLE
Use `dataset` in trimming not `"images"`

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -388,7 +388,7 @@
         "\n",
         "    with open_zarr(data_basename + zarr_ext, \"r\") as f:\n",
         "        # Load and prep data for computation.\n",
-        "        imgs = f[\"images\"]\n",
+        "        imgs = f[dataset]\n",
         "        da_imgs = da.from_array(imgs, chunks=(block_frames,) + imgs.shape[1:])\n",
         "\n",
         "        # Trim frames from front and back\n",


### PR DESCRIPTION
As this is determined by the dataset to read from is determined by input configuration at the beginning of the notebook, it needs to be used in the first computational step as well. After that using `"images"` or whatever else that is deemed appropriate is fine.