### PR TITLE
Use `block_frames` with the final ROI viewer

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1455,7 +1455,7 @@
         "\n",
         "    with open_zarr(fn, \"r\") as f:\n",
         "        imgs = f[\"images\"]\n",
-        "        da_imgs = da.from_array(imgs, chunks=(norm_frames,) + imgs.shape[1:])\n",
+        "        da_imgs = da.from_array(imgs, chunks=(block_frames,) + imgs.shape[1:])\n",
         "\n",
         "        with get_executor(client) as executor:\n",
         "            da_imgs_min, da_imgs_max = da_imgs.min(), da_imgs.max()\n",


### PR DESCRIPTION
Fix a typo from PR ( https://github.com/nanshe-org/nanshe_workflow/pull/152 ).

When visualizing the results of the ROIs on the data, use `block_frames` for chunking the data when finding the extents instead of using `norm_frames`, which is undefined in this case.