### PR TITLE
Set OPENBLAS_NUM_THREADS to 1 on Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -51,6 +51,10 @@ build:
           conda3 update -y --use-local --all
           conda3 clean -tipsy
     - script:
+        name: Restrict OpenBLAS to a single thread.
+        code: |-
+          export OPENBLAS_NUM_THREADS=1
+    - script:
         name: Configure the Python 2 iPython ipcluster profiles.
         code: |-
           python2 -m IPython profile create --parallel


### PR DESCRIPTION
Restricting OpenBLAS to one thread on Wercker as is done on the cluster and in the Docker image.

xref: https://github.com/nanshe-org/docker_nanshe_workflow/pull/34