### PR TITLE
Explicitly load the label image from Zarr

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1386,7 +1386,7 @@
         "    )\n",
         "\n",
         "    f2 = zarr.open_group(data_basename + postfix_rois + zarr_ext, \"r\")\n",
-        "    lblimg = f2[\"labels\"]\n",
+        "    lblimg = f2[\"labels\"][...]\n",
         "    lblimg_msk = numpy.ma.masked_array(lblimg, mask=(lblimg==0))\n",
         "\n",
         "    mplsv.viewer.matshow(lblimg_msk, alpha=0.3, cmap=mpl.cm.jet)\n",


### PR DESCRIPTION
Follow-up to PR ( https://github.com/nanshe-org/nanshe_workflow/pull/167 )

If we don't explicitly load the label image, `lblimg`, from Zarr, it appears the comparison with `0` (i.e. `lblimg==0` ) evaluates to `False` resulting in no mask. As a result the background that does not correspond a label is covered with an unnecessary color layer (with some transparency). This explicitly loads the label image data into a NumPy Array. Thus the non-labeled background is fixed to be completely transparent in the label image layer.