### PR TITLE
Ignore `dask-worker-space/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dask-worker-script*
 [0-9]*.err
 [0-9]*.out
 worker-*/
+dask-worker-space/


### PR DESCRIPTION
Make sure `git` ignores the `dask-worker-space/` directory that recent versions of `distributed` create.