### PR TITLE
Store input data under images in Zarr

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -240,7 +240,7 @@
         "elif data_ext == h5_ext:\n",
         "    a = dask_load_hdf5(data, dataset)\n",
         "\n",
-        "dask_store_zarr(data_basename + zarr_ext, [dataset], [a], client)\n",
+        "dask_store_zarr(data_basename + zarr_ext, [\"images\"], [a], client)\n",
         "\n",
         "del a"
       ]
@@ -268,7 +268,7 @@
         "\n",
         "f = zarr.open_group(fn, \"r\")\n",
         "\n",
-        "imgs = f[dataset]\n",
+        "imgs = f[\"images\"]\n",
         "da_imgs = da.from_array(imgs, chunks=(norm_frames,) + imgs.shape[1:])\n",
         "\n",
         "da_imgs_min, da_imgs_max = da_imgs.min(), da_imgs.max()\n",
@@ -319,7 +319,7 @@
         "\n",
         "# Load and prep data for computation.\n",
         "f = zarr.open_group(data_basename + zarr_ext, \"r\")\n",
-        "imgs = f[dataset]\n",
+        "imgs = f[\"images\"]\n",
         "da_imgs = da.from_array(imgs, chunks=(block_frames,) + imgs.shape[1:])\n",
         "\n",
         "# Trim frames from front and back\n",


### PR DESCRIPTION
In an attempt to standardize things a bit, store the input data to the workflow under the `"images"` dataset in Zarr.