### PR TITLE
Use single progress bar to track removal

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -104,7 +104,7 @@ def dask_io_remove(name, executor=None):
     if executor is None:
         return rm_task
 
-    display(dask.distributed.progress(executor.compute(rm_task)))
+    display(dask.distributed.progress(executor.compute(rm_task), multi=False))
 
 
 def zip_dir(dirname, compression=zipfile.ZIP_STORED, allowZip64=True):


### PR DESCRIPTION
Instead of using multiple progress bars for each removal task, simply use one progress bar to provide a summary of how much has been done. If the user wants more information, they would be better off to visit the Dask Dashboard. Otherwise these progress bars eat up too much visual space in the workflow.