### PR TITLE
Return the future from `dask_io_remove`

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -104,7 +104,7 @@ def dask_io_remove(name, executor=None):
     if executor is None:
         return rm_task
 
-    display(dask.distributed.progress(executor.compute(rm_task), multi=False))
+    return executor.compute(rm_task)
 
 
 def zip_dir(dirname, compression=zipfile.ZIP_STORED, allowZip64=True):


### PR DESCRIPTION
Instead of trying to create a progress bar for removal (which is largely uninteresting to the user), simply return the future if the computation was already submitted. That way they can block or create progress bars as needed. Alternatively they can just ignore the removal and proceed to later computations since the removal is a non-blocking step.