### PR TITLE
Require `python-graphviz`

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - jupyter_contrib_nbextensions
     - dask-core
     - toolz >=0.7.3
+    - python-graphviz
     - pyyaml
     - distributed
     - dask-drmaa


### PR DESCRIPTION
While we don't strictly need `python-graphviz`, it is convenient to have `python-graphviz` if we ever want to visualize any of the Dask graphs behind Dask objects. This need comes up often enough that it is better to just require `python-graphviz`. Hence we add `python-graphviz` to our run requirements for the workflow. This should also aid in any demonstrations that we may wish to do with the workflow as well.