### PR TITLE
Use NumPy's asarray

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -638,7 +638,7 @@
         "da_imgs_trunc_shape = da_imgs.shape[1:]\n",
         "for i in irange(len(da_imgs)):\n",
         "    slice_i = [i]\n",
-        "    shift_i = numpy.array(shifts[i])[()]\n",
+        "    shift_i = numpy.asarray(shifts[i])[()]\n",
         "    for j in irange(len(shift_i)):\n",
         "        shifts_ij = shift_i[j]\n",
         "        if shifts_ij < 0:\n",

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -375,7 +375,7 @@ class LazyHDF5Dataset(LazyDataset):
                                 key_rsort += (slice(None),)
                                 continue
 
-                            each_key = numpy.array(each_key)
+                            each_key = numpy.asarray(each_key)
                             each_key_sort = numpy.argsort(each_key)
                             each_key_rsort = numpy.concatenate([
                                 each_key_sort[None],

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -217,7 +217,7 @@ def save_tiff(fn, a):
         os.remove(fn)
     with tifffile.TiffWriter(fn, bigtiff=True) as tif:
         for i in irange(a.shape[0]):
-            tif.save(numpy.array(a[i]))
+            tif.save(numpy.asarray(a[i]))
 
 
 @contextmanager

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -653,7 +653,7 @@ def block_generate_dictionary_parallel(client, calculate_block_shape, calculate_
             def calculate_block(db, dbds, kw):
                 with dask.set_options(get=dask.get):
                     return zarr.array(calculate(
-                        numpy.asarray(db[...]), numpy.array(dbds[...]), *new_args, **kw
+                        numpy.asarray(db[...]), numpy.asarray(dbds[...]), *new_args, **kw
                     ))
 
             result_blocks = executor.map(


### PR DESCRIPTION
Instead of using `numpy.array` in a few cases where a NumPy array could be provided as input, make use of `numpy.asarray`. This will avoid a copy if the input is already a NumPy array and so should improve performance.