### PR TITLE
Update Wercker's entrypoint to use entrypoint_2.sh

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,6 +1,6 @@
 box:
   id: nanshe/nanshe_notebook
-  entrypoint: /opt/conda/bin/tini -- /usr/share/docker/entrypoint.sh
+  entrypoint: /opt/conda/bin/tini -- /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh
 
 build:
   steps:


### PR DESCRIPTION
As `entrypoint.sh` is now used as the entrypoint of the `jakirkham/centos_conda` image and `entrypoint_2.sh` is needed to configure and launch SGE on the `jakirkham/centos_drmaa_conda` image, update the `entrypoint` used by Wercker to include `entrypoint_2.sh` as well.

Note: A similar change is being added to the Docker container as well. ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/38 )

xref: https://github.com/jakirkham/docker_centos_drmaa_conda/pull/44