### PR TITLE
Use `nanshe/nanshe_notebook:sge` on Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,5 +1,5 @@
 box:
-  id: "nanshe/nanshe_notebook:latest"
+  id: "nanshe/nanshe_notebook:sge"
   entrypoint: /opt/conda/bin/tini -- /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh
 
 build:

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,5 +1,5 @@
 box:
-  id: nanshe/nanshe_notebook
+  id: "nanshe/nanshe_notebook:latest"
   entrypoint: /opt/conda/bin/tini -- /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh
 
 build:


### PR DESCRIPTION
As SGE support will be removed from the `nanshe/nanshe_notebook:latest` ( https://github.com/nanshe-org/docker_nanshe/pull/26 ), use the `nanshe/nanshe_notebook:sge` image on Wercker for testing, which will continue to have and support SGE. This way the current CI testing on Wercker of the workflow will continue to operate correctly.

Note: The corresponding change is also being made to the Docker image in PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/39 ).