### PR TITLE
Drop usage of `set_num_workers` in the workflow

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -78,9 +78,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from nanshe_workflow.par import set_num_workers, startup_distributed\n",
+        "from psutil import cpu_count\n",
+        "from nanshe_workflow.par import startup_distributed\n",
         "\n",
-        "num_workers = set_num_workers(num_workers)\n",
+        "num_workers = (num_workers or cpu_count())\n",
         "\n",
         "client = startup_distributed(num_workers)\n",
         "\n",


### PR DESCRIPTION
We no longer have a `CORES` environment variable that we need to set so one of `set_num_workers` use cases is unneeded. Further following the user's specifications on the number of workers to user is more straightforward now. In other words, we don't need to factor in a scheduler process. Given these changes just use `psutil`'s `cpu_count` directly in the workflow if `num_workers` is not provided. This doesn't handle the `-1` case. However it isn't that big of a deal for the user to adapt as this is user facing code that is deployed with the user for analysis.