### PR TITLE
Force Dask's DRMAACluster to 1 thread per worker

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -145,6 +145,9 @@ def startup_distributed(nworkers):
     if dask_drmaa:
         cluster = dask_drmaa.DRMAACluster(
             template={
+                "args": [
+                    "--nthreads", "1"
+                ],
                 "jobEnvironment": os.environ
             }
         )

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -144,7 +144,9 @@ def startup_distributed(nworkers):
 
     if dask_drmaa:
         cluster = dask_drmaa.DRMAACluster(
-            template={"jobEnvironment": os.environ}
+            template={
+                "jobEnvironment": os.environ
+            }
         )
         cluster.start_workers(nworkers)
     else:


### PR DESCRIPTION
When we startup the Dask `LocalCluster`, we make sure to set the number of threads per worker to 1 as we want to only use 1 core per worker. However the same is not currently done with Dask's `DRMAACluster`. This fixes that issue by ensuring the `dask-worker` CLI gets a command line option to specify 1 core per worker. As the number of cores per worker affects how memory limits are estimated, we definitely want to make sure Dask doesn't think the upper bound is the total memory on the node, but only the amount of memory given per slot.