### PR TITLE
Provide optional kwargs in startup_distributed

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -38,6 +38,8 @@
         "dataset = \"images\"\n",
         "\n",
         "num_workers = None\n",
+        "cluster_kwargs = {}\n",
+        "client_kwargs = {}\n",
         "\n",
         "\n",
         "import os\n",
@@ -82,7 +84,7 @@
         "\n",
         "num_workers = set_num_workers(num_workers)\n",
         "\n",
-        "client = startup_distributed(num_workers)\n",
+        "client = startup_distributed(num_workers, cluster_kwargs, client_kwargs)\n",
         "\n",
         "client"
       ]

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -139,8 +139,12 @@ def get_client(profile):
     return(client)
 
 
-def startup_distributed(nworkers):
+def startup_distributed(nworkers, cluster_kwargs=None, client_kwargs=None):
     nworkers = int(nworkers)
+    if cluster_kwargs is None:
+        cluster_kwargs = {}
+    if client_kwargs is None:
+        client_kwargs = {}
 
     if dask_drmaa:
         cluster = dask_drmaa.DRMAACluster(
@@ -149,17 +153,18 @@ def startup_distributed(nworkers):
                     "--nthreads", "1"
                 ],
                 "jobEnvironment": os.environ
-            }
+            },
+            **cluster_kwargs
         )
         cluster.start_workers(nworkers)
     else:
         # Either `dask_drmaa` is unavailable or DRMAA cannot start.
         # Fallback to a local Distributed client instead.
         cluster = distributed.LocalCluster(
-            n_workers=nworkers, threads_per_worker=1
+            n_workers=nworkers, threads_per_worker=1, **cluster_kwargs
         )
 
-    client = distributed.Client(cluster)
+    client = distributed.Client(cluster, **client_kwargs)
     while (
               (client.status == "running") and
               (len(client.scheduler_info()["workers"]) < nworkers)

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -164,7 +164,7 @@ def startup_distributed(nworkers):
               (client.status == "running") and
               (len(client.scheduler_info()["workers"]) < nworkers)
           ):
-        sleep(1)
+        sleep(1.0)
 
     return client
 


### PR DESCRIPTION
Adds the option in `startup_distributed` to provide some additional keyword arguments for the cluster constructor and for the `Client` constructor. This should provide some needed flexibility for when the startup of the Distributed cluster and Client need further customization (e.g. prefacing the startup function with something). Will be helpful when running the workflow under singularity.