### PR TITLE
Add and use DistributedDirectoryStore with Zarr

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -242,10 +242,10 @@ class DistributedDirectoryStore(zarr.DirectoryStore):
 @contextmanager
 def open_zarr(name, mode="r"):
     if not os.path.exists(name) and mode in ["a", "w"]:
-        store = zarr.DirectoryStore(name)
+        store = DistributedDirectoryStore(name)
         yield zarr.open_group(store, mode)
     elif os.path.isdir(name):
-        store = zarr.DirectoryStore(name)
+        store = DistributedDirectoryStore(name)
         yield zarr.open_group(store, mode)
     elif zipfile.is_zipfile(name):
         with zarr.ZipStore(name, mode=mode, compression=0, allowZip64=True) as store:

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -220,6 +220,25 @@ def save_tiff(fn, a):
             tif.save(numpy.asarray(a[i]))
 
 
+class DistributedDirectoryStore(zarr.DirectoryStore):
+    def __delitem__(self, key):
+        path = os.path.join(self.path, key)
+        if os.path.exists(path):
+            dask.distributed.fire_and_forget(dask_io_remove(path))
+        else:
+            raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        # Delete in parallel, asynchronously.
+        # Immediately makes room for new key-value pair.
+        try:
+            del self[key]
+        except KeyError:
+            pass
+
+        super(DistributedDirectoryStore, self).__setitem__(key, value)
+
+
 @contextmanager
 def open_zarr(name, mode="r"):
     if not os.path.exists(name) and mode in ["a", "w"]:


### PR DESCRIPTION
Adds and makes use of the `DistributedDirectoryStore` with Zarr. It is the same as a `DirectoryStore` except that deletion proceeds asynchronously and in parallel via the Dask Distributed cluster. This impacts both `__delitem__` and `__setitem__`. All other methods of `DirectoryStore` are left unchanged. This is used with `open_zarr` to provide Zarr Groups that can handle deleting data in this nice way.