### PR TITLE
Tornado 5 fixes

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -193,8 +193,6 @@ def shutdown_distributed(client):
         for w in workers:
             cluster.stop_worker(w)
 
-    while len(cluster.workers) != 0:
-        sleep(1)
     cluster.close()
 
 

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -188,7 +188,7 @@ def shutdown_distributed(client):
     try:
         cluster.stop_worker
     except AttributeError:
-        cluster.stop_workers(workers)
+        cluster.stop_workers(workers, sync=True)
     else:
         for w in workers:
             cluster.stop_worker(w)


### PR DESCRIPTION
The `while`-`sleep` check for Distributed Cluster workers to shutdown was causing a hang when using SGE and Tornado 5. Getting rid of it fixes the issue; however, it doesn't solve the issue of ensuring all workers from either DRMAA or Local Cluster are shutdown.

To fix this, shut down the DRMAA Cluster workers using `stop_workers` with `sync=True`. This ensures that DRMAA will block our process until all workers are shutdown. Once DRMAA releases our process, all of the DRMAA workers are shutdown making the check unnecessary in this case. In the Local Cluster case, `stop_worker` is already blocking and does not return until the worker in question is shutdown.

IOW these changes ensure that all workers are shutdown for the DRMAA or Local Cluster as appropriate without any additional blocking. Also with these changes the workflow works with Tornado 4 and Tornado 5.