### PR TITLE
Run persist on removal task before fire_and_forget

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -229,7 +229,7 @@ class DistributedDirectoryStore(zarr.DirectoryStore):
     def __delitem__(self, key):
         path = os.path.join(self.path, key)
         if os.path.exists(path):
-            dask.distributed.fire_and_forget(dask_io_remove(path))
+            dask.distributed.fire_and_forget(dask_io_remove(path).persist())
         else:
             raise KeyError(key)
 


### PR DESCRIPTION
As `fire_and_forget` only collects `Futures` from a task and does not actually submit the task for computation and we don't submit a task for computation from `dask_io_remove` unless a `Client` is provided, we are left to submit the task ourselves to ensure that we get `Futures` first.

Hence we call `persist` here to trigger a computation and return `Futures` that can be passed to `fire_and_forget`. We know `Futures` should be returned as we are currently using a `Client`. However if we weren't using a `Client`, calling `persist` would be the same as `compute` ensuring removal occurred making `fire_and_forget` a no-op (as there would be no `Futures`). IOW this now has the right behavior in all cases.