### PR TITLE
Use fire_and_forget on Future in dask_store_zarr

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -212,6 +212,7 @@ def dask_store_zarr(filename, datasetnames, datasets, executor):
         status = executor.compute(dask.array.store(
             dask_arrays, zarr_arrays, lock=False, compute=False
         ))
+        dask.distributed.fire_and_forget(status)
 
         dask.distributed.progress(status, notebook=False)
         print("")


### PR DESCRIPTION
Even though we effectively block in `dask_store_zarr` currently by using the non-notebook progress bar, call `fire_and_forget` on the `Future` gotten from calling `compute` on the `dask.array.store`'s `Delayed` object. This way we can be sure that storing the results will complete even if blocking didn't occur with the progress bar in the future.