### PR TITLE
Use fire_and_forget on registration shifts

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -536,6 +536,7 @@
         "\n",
         "    # Persist values needed for the next iteration (and end of this one).\n",
         "    da_imgs_fft_tmplt, shifts, avg_rel_dist = client.persist([da_imgs_fft_tmplt, shifts, avg_rel_dist])\n",
+        "    dask.distributed.fire_and_forget(shifts)\n",
         "\n",
         "    # Compute change\n",
         "    status = client.compute(avg_rel_dist)\n",


### PR DESCRIPTION
As the registration shifts are always needed whether another loop of registration is required or registration is complete and we want to store the result, send the shifts to `fire_and_forget`. While we should always hold on to the `shifts` (and thus the relevant `Futures`), go ahead and make sure they will be computed by sending them to `fire_and_forget`. That way we can sure the `shifts` will be computed no matter what.