### PR TITLE
Update test files to remove in teardown script

### DIFF
--- a/teardown_tests.py
+++ b/teardown_tests.py
@@ -12,18 +12,8 @@ if not os.environ.get("TEST_NOTEBOOKS"):
 for each in list(sys.argv[1:]) + [
     "data.tif",
     "data.h5",
-    "data_trim.h5",
-    "data_dn.h5",
-    "data_reg.h5",
-    "data_sub.h5",
-    "data_f_f0.h5",
-    "data_wt.h5",
-    "data_norm.h5",
-    "data_dict.h5",
-    "data_post.h5",
     "data_traces.h5",
     "data_rois.h5",
-    "data_proj.h5",
     "data.zarr",
     "data_trim.zarr",
     "data_dn.zarr",
@@ -37,7 +27,8 @@ for each in list(sys.argv[1:]) + [
     "data_traces.zarr",
     "data_rois.zarr",
     "data_proj.zarr",
-    "data_proj.html"]:
+    "data_proj.html",
+    "dask-worker-space"]:
     if os.path.isfile(each):
         os.remove(each)
     elif os.path.isdir(each):


### PR DESCRIPTION
Drops HDF5 files that are no longer generated during routine testing from teardown. Also adds Dask's workspace directory for cleanup.

xref: https://github.com/nanshe-org/nanshe_workflow/pull/126 (dropped storing HDF5 files)
xref: https://github.com/nanshe-org/nanshe_workflow/pull/49 (started using Dask)