### PR TITLE
Require dask-ndmeasure

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - dask-imread
     - dask-ndfilters
     - dask-ndfourier
+    - dask-ndmeasure
     - cloudpickle
     - tifffile
     - imgroi


### PR DESCRIPTION
Will be needed to perform connected components and to constrain the resulting label image. The code that will use `dask-ndmeasure` is still being explored. However as a new image needs to be built and having this dependency would aid in exploration, go ahead and include `dask-ndmeasure` now.