### PR TITLE
Fix the dictionary's input block shape

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1143,7 +1143,7 @@
         "\n",
         "imgs = dask_store._diskstore[subgroup_norm]\n",
         "\n",
-        "block_shape = (block_frames,) + da_imgs.shape[1:]\n",
+        "block_shape = (block_frames,) + imgs.shape[1:]\n",
         "da_imgs = da.from_array(imgs, chunks=block_shape)\n",
         "\n",
         "new_result = dask_store._create_dataset(\n",


### PR DESCRIPTION
A (technically) undefined variable was being used to define the block shape of the input. This fixes it to use the images just loaded instead.