### PR TITLE
Use Python 3.6.5

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1768,7 +1768,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.6.4"
+      "version": "3.6.5"
     },
     "widgets": {
       "state": {},


### PR DESCRIPTION
Updates the notebook metadata to note that we are now running with Python 3.6.5 instead of 3.6.4.