### PR TITLE
Use adaptive scaling in the workflow

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -20,10 +20,7 @@
         "* `data_dir` (`str`): Where the data is located. (change if data is not in the current directory, normally is)\n",
         "* `data` (`str`): HDF5 file to use as input data.\n",
         "* `data_basename` (`str`): Basename to use for intermediate and final result files.\n",
-        "* `dataset` (`str`): HDF5 dataset to use as input data.\n",
-        "\n",
-        "</br>\n",
-        "* `num_workers` (`int`): Number of workers for iPython Cluster. (default all cores excepting one for client)"
+        "* `dataset` (`str`): HDF5 dataset to use as input data."
       ]
     },
     {
@@ -37,9 +34,9 @@
         "data_basename = \"data\"\n",
         "dataset = \"images\"\n",
         "\n",
-        "num_workers = None\n",
         "cluster_kwargs = {}\n",
         "client_kwargs = {}\n",
+        "adaptive_kwargs = {}\n",
         "\n",
         "\n",
         "import os\n",
@@ -108,12 +105,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from nanshe_workflow.par import set_num_workers, startup_distributed\n",
+        "from nanshe_workflow.par import startup_distributed\n",
         "from nanshe_workflow.data import DistributedArrayStore\n",
         "\n",
-        "num_workers = set_num_workers(num_workers)\n",
-        "\n",
-        "client = startup_distributed(num_workers, cluster_kwargs, client_kwargs)\n",
+        "client = startup_distributed(0, cluster_kwargs, client_kwargs, adaptive_kwargs)\n",
         "\n",
         "dask_store = DistributedArrayStore(zarr_store, client=client)\n",
         "\n",

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -139,7 +139,10 @@ def get_client(profile):
     return(client)
 
 
-def startup_distributed(nworkers, cluster_kwargs=None, client_kwargs=None):
+def startup_distributed(nworkers,
+                        cluster_kwargs=None,
+                        client_kwargs=None,
+                        adaptive_kwargs=None):
     nworkers = int(nworkers)
     if cluster_kwargs is None:
         cluster_kwargs = {}
@@ -163,6 +166,9 @@ def startup_distributed(nworkers, cluster_kwargs=None, client_kwargs=None):
         cluster = distributed.LocalCluster(
             n_workers=nworkers, threads_per_worker=1, **cluster_kwargs
         )
+
+    if adaptive_kwargs is not None:
+        cluster.adapt(**adaptive_kwargs)
 
     client = distributed.Client(cluster, **client_kwargs)
     while (


### PR DESCRIPTION
Makes use of Distributed's adaptive scaling capabilities. This avoids the need to specify some number of workers to dispatch or the need to clean them up afterwards. Does this by only adding jobs to the cluster as work demands and removing them after that work is completed. Should be more friendly when engaging with other users on the cluster as jobs are transient. Also should help keep the cost down as jobs won't sit idle between tasks.