### PR TITLE
Delete popped value from store after loading it

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -727,7 +727,7 @@ class DistributedArrayStore(collections.MutableMapping):
                 value = self._client.persist(value)
                 dask.distributed.wait(value)
 
-        del self._diskstore[key]
+        del self[key]
 
         return value
 


### PR DESCRIPTION
Previously in `DistributedArrayStore`'s `pop`, only the data on disk was removed. However the Dask Array in `_memstore` also needs to be cleaned up. This includes canceling the `Future`s of the Dask Array so that no one tries to reload it from disk (given the disk representation has expired). Instead of trying to recreate the nice process already in `DistributedArrayStore`'s `__delitem__`, go ahead and call `__delitem__` after loading the data from disk into Distributed's persisted memory. This handles dropping the Dask Array from our in memory cache, canceling the `Future`s to block other computations dependent on that result, and removing the on disk data.