### PR TITLE
Bump default Jupyter Notebook timeout to 60s

### DIFF
--- a/test_nanshe_workflow.py
+++ b/test_nanshe_workflow.py
@@ -23,12 +23,10 @@ class TestNansheWorkflow(unittest.TestCase):
             "nanshe_ipython.ipynb",
         ]
 
-        timeout_opt = ""
-        if "NB_EXE_TIMEOUT" in os.environ:
-            timeout_opt = (
-                "--ExecutePreprocessor.timeout=%s" %
-                os.environ["NB_EXE_TIMEOUT"]
-            )
+        timeout_opt = (
+            "--ExecutePreprocessor.timeout=%s" %
+            os.environ.get("NB_EXE_TIMEOUT", "60")
+        )
 
         for each_nb_filename in nb_filenames:
             argv = (


### PR DESCRIPTION
Appears the tests are getting closer to the default Jupyter Notebook timeout of 30s and sometimes going over. So bump the timeout default for our tests to 60s, which should provide plenty enough time for the tests to complete. This change will carry over nicely to CI and the Docker image build.