### PR TITLE
Provide block_chunks parameter for loading data

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -260,7 +260,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Convert TIFF/HDF5 to Zarr"
+        "### Convert TIFF/HDF5 to Zarr\n",
+        "\n",
+        "* `block_chunks` (`tuple` of `int`s): chunk size for each block loaded into memory."
       ]
     },
     {
@@ -269,13 +271,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "block_chunks = (100, -1, -1)\n",
+        "\n",
         "with suppress(KeyError):\n",
         "    del dask_store[subgroup_raw]\n",
         "\n",
         "if data_ext == tiff_ext:\n",
-        "    dask_store[subgroup_raw] = dask_imread.imread(data)\n",
+        "    dask_store[subgroup_raw] = dask_imread.imread(data, nframes=block_chunks[0])\n",
         "elif data_ext == h5_ext:\n",
-        "    dask_store[subgroup_raw] = dask_load_hdf5(data, dataset)\n",
+        "    dask_store[subgroup_raw] = dask_load_hdf5(data, dataset, chunks=block_chunks)\n",
         "\n",
         "dask.distributed.progress(dask_store[subgroup_raw], notebook=False)"
       ]

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -164,6 +164,10 @@ def dask_load_hdf5(fn, dn, chunks=None):
         dtype = fh[dn].dtype
         if chunks is None:
             chunks = fh[dn].chunks
+        else:
+            chunks = tuple(
+                es if ec == -1 else ec for es, ec in zip(shape, chunks)
+            )
 
     def _read_chunk(fn, dn, idx):
         with h5py.File(fn) as fh:


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/nanshe_workflow/issues/215

Adds a `block_chunks` parameter for loading data from HDF5, TIFF, or other image formats into memory with a specific chunk size in Dask and in the resulting Zarr storage of this data. With image files, this only specifies the number of frames in each chunk.

To help facilitate this and standardize between HDF5 and other image formats, allow HDF5 to handle `-1` in chunks and replace them with the length of that dimension.