### PR TITLE
Breakout cluster arguments and set adaptive cluster worker limits

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -34,10 +34,6 @@
         "data_basename = \"data\"\n",
         "dataset = \"images\"\n",
         "\n",
-        "cluster_kwargs = {}\n",
-        "client_kwargs = {}\n",
-        "adaptive_kwargs = {}\n",
-        "\n",
         "\n",
         "import os\n",
         "\n",
@@ -77,6 +73,20 @@
         "tiff_ext = os.path.extsep + \"tif\"\n",
         "zarr_ext = os.path.extsep + \"zarr\"\n",
         "html_ext = os.path.extsep + \"html\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from psutil import cpu_count\n",
+        "\n",
+        "cluster_kwargs = {}\n",
+        "client_kwargs = {}\n",
+        "adaptive_kwargs = {}"
       ]
     },
     {

--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -86,7 +86,10 @@
         "\n",
         "cluster_kwargs = {}\n",
         "client_kwargs = {}\n",
-        "adaptive_kwargs = {}"
+        "adaptive_kwargs = {\n",
+        "    \"minimum\": 0,\n",
+        "    \"maximum\": int(os.environ.get(\"CORES\", cpu_count())) - 1\n",
+        "}"
       ]
     },
     {


### PR DESCRIPTION
Moves the Distributed cluster arguments into their own cell. Also sets default minimum and maximum worker limits for the Adaptive cluster based on the CPU cores available on a single machine. These can be (and probably should be for non-local deployments) overridden as needed.