### PR TITLE
Call `cluster.adapt()` during shutdown

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -183,6 +183,11 @@ def startup_distributed(nworkers,
 def shutdown_distributed(client):
     cluster = client.cluster
 
+    # Will close and clear an existing adaptive instance
+    with distributed.utils.ignoring(AttributeError):
+        cluster._adaptive.stop()
+        del cluster._adaptive
+
     client.close()
     while (
               (client.status == "running") and


### PR DESCRIPTION
For some reason during shutdown of the `Cluster`, it appears that the `Adaptive` portion starts requesting workers (resisting our attempts to close them out). As a workaround, call `cluster._adaptive.stop()`, which closes out the existing `Adaptive` instance and then delete it. If the `Cluster` does not have an `Adaptive` instance, just skip this step.