### PR TITLE
Show Cluster widget after startup

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -129,6 +129,15 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "client.cluster"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {},
       "source": [


### PR DESCRIPTION
Display the Jupyter Notebook widget for tweaking the Cluster settings right after starting up the Cluster and Client.