### PR TITLE
Require dask-ndmorph

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - dask-ndfilters
     - dask-ndfourier
     - dask-ndmeasure
+    - dask-ndmorph
     - cloudpickle
     - tifffile
     - imgroi


### PR DESCRIPTION
Currently we are not using `dask-ndmorph`. However this will be useful for playing with different thresholding and connected component strategies. So go ahead and add it in preemptively so that we can rebuild the container with this dependency included and deploy it.