### PR TITLE
Skip Distributed versions with _repr_html_

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - toolz >=0.7.3
     - python-graphviz
     - pyyaml
-    - distributed
+    - distributed !=1.21.7,!=1.21.8
     - dask-drmaa
     - dask-imread
     - dask-ndfilters


### PR DESCRIPTION
Some of the newer versions of Distributed (namely 1.21.7 and 1.21.8) have a bug with `_repr_html_` being used on closed `Client` objects. As we rely on being able to use this functionality, mark these versions of `distributed` as incompatible with the workflow.

xref: https://github.com/dask/distributed/issues/1963