### PR TITLE
Backport "Improve `DistributedArrayStore`'s `__iter__` and `__len__` implementations" to 2.x

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -643,7 +643,7 @@ class DistributedArrayStore(collections.MutableMapping):
         return iter_recurse(self._diskstore)
 
     def __len__(self):
-        return len(self._diskstore)
+        return sum(imap(lambda e: 1, iter(self)))
 
     def __contains__(self, key):
         return (key in self._diskstore)

--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -632,7 +632,15 @@ class DistributedArrayStore(collections.MutableMapping):
         del self._diskstore[key]
 
     def __iter__(self):
-        return iter(self._diskstore)
+        def iter_recurse(obj):
+            for k in obj:
+                if isinstance(obj[k], collections.MutableMapping):
+                    for k2 in iter_recurse(obj[k]):
+                        yield "/".join([k, k2])
+                else:
+                    yield k
+
+        return iter_recurse(self._diskstore)
 
     def __len__(self):
         return len(self._diskstore)


### PR DESCRIPTION
Backport PR ( https://github.com/nanshe-org/nanshe_workflow/pull/241 )

Reimplement `__iter__` to recursively handle nested `MutableMapping`s and only returning the non-`MutableMapping` leaves it finds. Use the standard `/` to separate multiple keys as is common in H5py, Zarr, etc. and as it is quasi-supported now through those same implementations. This allows users to explore only the Arrays stored and not any of the internal spec (i.e. Groups).

Also rewrite `__len__` to use `__iter__` in it's determination of length by simply summing `1` for each entry.