### PR TITLE
Backport "Require dask-ml" to 2.x

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - dask-ndfourier
     - dask-ndmeasure
     - dask-ndmorph
+    - dask-ml
     - cloudpickle
     - tifffile
     - imgroi


### PR DESCRIPTION
Backport PR ( https://github.com/nanshe-org/nanshe_workflow/pull/242 )

While we are not using `dask-ml` yet, we expect to soon start using it. So go ahead and add it as a requirement. That way we can include it in builds we do in the near future.