### PR TITLE
Drop IPython 3 support for the workflow

### DIFF
--- a/nanshe_workflow/ipy.py
+++ b/nanshe_workflow/ipy.py
@@ -2,25 +2,7 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Nov 10, 2015 17:09$"
 
 
-try:
-    from IPython.utils.shimmodule import ShimWarning
-except ImportError:
-    class ShimWarning(Warning):
-        """Warning issued by IPython 4.x regarding deprecated API."""
-        pass
-
-import warnings
-
-with warnings.catch_warnings():
-    warnings.filterwarnings('error', '', ShimWarning)
-
-    try:
-        # IPython 3
-        from IPython.html.widgets import FloatProgress
-        from IPython.parallel import Client
-    except ShimWarning:
-        # IPython 4
-        from ipywidgets import FloatProgress
-        from ipyparallel import Client
+from ipywidgets import FloatProgress
+from ipyparallel import Client
 
 from IPython.display import display

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -80,19 +80,8 @@ def cleanup_cluster_files(profile):
             profile(str):           Which iPython profile to clean up for.
     """
 
-    try:
-        # iPython 4.x solution
-        from IPython.paths import locate_profile
-    except ImportError:
-        # iPython 3.x solution
-        from IPython.utils.path import locate_profile
-
-    try:
-        # iPython 3.x solution (use iPython 4.x name)
-        from IPython.utils.path import get_security_file as find_connection_file
-    except ImportError:
-        # iPython 4.x solution
-        from ipykernel.connect import find_connection_file
+    from IPython.paths import locate_profile
+    from ipykernel.connect import find_connection_file
 
     for each_file in ["tasks.db", "tasks.db-journal"]:
         try:


### PR DESCRIPTION
We are now long past IPython 3 and the big split. IPython 5 and friends are the last release supporting Python 2 and are already well developed. IPython 6 is out for Python 3+ and has seen a few releases. It's safe to say that IPython 3 does not need to be considered here. So drop the code designed to support the old monolithic IPython.