### PR TITLE
Keep persisting the image stack minimum

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -606,7 +606,6 @@
         "da_imgs_flt_min, da_imgs_fft, da_imgs_fft_tmplt = client.persist([\n",
         "    da_imgs_flt_min, da_imgs_fft, da_imgs_fft_tmplt\n",
         "])\n",
-        "dask.distributed.fire_and_forget(da_imgs_flt_min)\n",
         "del da_imgs_flt_min\n",
         "\n",
         "while avg_rel_dist > thld_rel_dist and i < num_reps:\n",


### PR DESCRIPTION
The minimum of the image stack is used as an intermediate in other computations. As such there is no need to forget it's `Future`s. Hence drop the call to `fire_and_forget`.