### PR TITLE
Use Python 3.6.6 (for 2.x)

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1777,7 +1777,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.6.5"
+      "version": "3.6.6"
     },
     "widgets": {
       "state": {},


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/262 ) for 2.x.

Bump the workflow's Python version to 3.6.6.