### PR TITLE
Fix typo in `DistributedArrayStore.__setitem__` (for 2.x)

### DIFF
--- a/nanshe_workflow/data.py
+++ b/nanshe_workflow/data.py
@@ -615,8 +615,8 @@ class DistributedArrayStore(collections.MutableMapping):
                 key (str): key to delete
 
             Note:
-                Use ``pop`` if the data needs to kept around outside the store
-                after removal.
+                Use ``pop`` if the data needs to be kept around outside the
+                store after removal.
         """
 
         if key not in self:


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/265 ) for 2.x.