### PR TITLE
Use `scheduler` argument to set temporary `Client`

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - ipywidgets
     - jupyter_contrib_nbextensions
     - nbserverproxy  # [py>=35]
-    - dask-core >=0.18.0
+    - dask-core >=0.19.4
     - toolz >=0.7.3
     - python-graphviz
     - pyyaml

--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - toolz >=0.7.3
     - python-graphviz
     - pyyaml
-    - distributed !=1.21.7,!=1.21.8
+    - distributed >=1.22
     - dask-drmaa
     - dask-image
     - dask-ml


### PR DESCRIPTION
Now that Dask supports a way of setting the `Client` instance used in the `config` (particularly temporarily), make use of that to configure the `Client` instance used in select blocks where it is relevant.

xref: https://github.com/dask/dask/pull/4062