### PR TITLE
Handle dropped Joblib module in Distributed 1.24.0 (for 2.x)

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -209,6 +209,7 @@
         "from nanshe.imp.segment import generate_dictionary\n",
         "\n",
         "import nanshe_workflow\n",
+        "import nanshe_workflow._reg_joblib\n",
         "from nanshe_workflow.data import io_remove, dask_io_remove, dask_load_hdf5, dask_store_zarr, zip_zarr, open_zarr\n",
         "\n",
         "zarr.blosc.set_nthreads(1)\n",

--- a/nanshe_workflow/_reg_joblib.py
+++ b/nanshe_workflow/_reg_joblib.py
@@ -1,0 +1,18 @@
+import dask
+import dask.distributed
+
+import distributed
+
+try:
+    import dask.distributed.joblib
+except ImportError:
+    pass
+
+try:
+    import distributed.joblib
+except ImportError:
+    pass
+
+import sklearn
+import sklearn.externals
+import sklearn.externals.joblib


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/270 ) for 2.x.

The very latest version of Distributed dropped the `joblib` module. So this adapts to that change.