### PR TITLE
Use `scheduler` argument to set temporary `Client` (for 2.x)

### DIFF
--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - ipywidgets
     - jupyter_contrib_nbextensions
     - nbserverproxy  # [py>=35]
-    - dask-core >=0.18.0
+    - dask-core >=0.19.4
     - toolz >=0.7.3
     - python-graphviz
     - pyyaml

--- a/nanshe_workflow.recipe/meta.yaml
+++ b/nanshe_workflow.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - toolz >=0.7.3
     - python-graphviz
     - pyyaml
-    - distributed !=1.21.7,!=1.21.8
+    - distributed >=1.22
     - dask-drmaa
     - dask-image
     - dask-ml


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/267 ) for 2.x.