### PR TITLE
Use `dask.distributed` instead of `distributed` (for 2.x)

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1445,7 +1445,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import distributed\n",
+        "import dask.distributed\n",
         "from nanshe_workflow.par import shutdown_distributed\n",
         "\n",
         "try:\n",
@@ -1453,7 +1453,7 @@
         "except NameError:\n",
         "    pass\n",
         "\n",
-        "client = distributed.client.default_client()\n",
+        "client = dask.distributed.client.default_client()\n",
         "\n",
         "shutdown_distributed(client)\n",
         "\n",

--- a/nanshe_workflow/_reg_joblib.py
+++ b/nanshe_workflow/_reg_joblib.py
@@ -1,15 +1,8 @@
 import dask
 import dask.distributed
 
-import distributed
-
 try:
     import dask.distributed.joblib
-except ImportError:
-    pass
-
-try:
-    import distributed.joblib
 except ImportError:
     pass
 

--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -17,10 +17,9 @@ from psutil import cpu_count
 import numpy
 import zarr
 
-import distributed
-
 import dask
 import dask.array
+import dask.distributed
 
 try:
     import dask_drmaa
@@ -168,12 +167,12 @@ def startup_distributed(nworkers,
         # Fallback to a local Distributed client instead.
         cluster_kwargs_pass.setdefault("n_workers", nworkers)
         cluster_kwargs_pass.setdefault("threads_per_worker", 1)
-        cluster = distributed.LocalCluster(**cluster_kwargs_pass)
+        cluster = dask.distributed.LocalCluster(**cluster_kwargs_pass)
 
     if adaptive_kwargs is not None:
         cluster.adapt(**adaptive_kwargs)
 
-    client = distributed.Client(cluster, **client_kwargs)
+    client = dask.distributed.Client(cluster, **client_kwargs)
     while (
               (client.status == "running") and
               (len(client.scheduler_info()["workers"]) < nworkers)
@@ -189,7 +188,7 @@ def shutdown_distributed(client):
     cluster = client.cluster
 
     # Will close and clear an existing adaptive instance
-    with distributed.utils.ignoring(AttributeError):
+    with dask.distributed.utils.ignoring(AttributeError):
         cluster._adaptive.stop()
         del cluster._adaptive
 


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/278 ) for 2.x.