### PR TITLE
Use Dask Array FFT interface directly

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -241,12 +241,9 @@
       "outputs": [],
       "source": [
         "try:\n",
-        "    import pyfftw.interfaces.numpy_fft as numpy_fft\n",
+        "    import pyfftw.interfaces.dask_fft as dask_fft\n",
         "except ImportError:\n",
-        "    import numpy.fft as numpy_fft\n",
-        "\n",
-        "rfftn = da.fft.fft_wrap(numpy_fft.rfftn)\n",
-        "irfftn = da.fft.fft_wrap(numpy_fft.irfftn)"
+        "    import dask.array.fft as dask_fft"
       ]
     },
     {
@@ -592,7 +589,7 @@
         "da_imgs_inv = dask.array.reciprocal(da_imgs_flt - (da_imgs_flt_min - 1))\n",
         "\n",
         "# Compute the FFT of inverse frames and template\n",
-        "da_imgs_fft = rfftn(da_imgs_inv, axes=tuple(irange(1, da_imgs_flt.ndim)))\n",
+        "da_imgs_fft = dask_fft.rfftn(da_imgs_inv, axes=tuple(irange(1, da_imgs_flt.ndim)))\n",
         "da_imgs_fft_tmplt = da_imgs_fft.mean(axis=0, keepdims=True)\n",
         "\n",
         "# Initialize\n",
@@ -636,7 +633,7 @@
         "    del da_shifted_frames\n",
         "\n",
         "    # Find the best overlap with the template.\n",
-        "    da_overlap = irfftn(\n",
+        "    da_overlap = dask_fft.irfftn(\n",
         "        da_imgs_fft * da_imgs_fft_tmplt,\n",
         "        s=da_imgs_flt.shape[1:],\n",
         "        axes=tuple(irange(1, da_imgs_flt.ndim))\n",


### PR DESCRIPTION
Instead of manually wrapping NumPy's or optionally pyFFTW's NumPy-interface's FFTs, just use the pre-wrapped FFTs from Dask Array (based off of NumPy's FFTs) or optionally use pyFFTW's Dask Array-interface's FFTs. This simplifies the wrapping work a bit as this is managed and tested by other libraries. So should just work for us. Though requires a newer version of FFTW.