### PR TITLE
Drop `zlib` import for ROI trace plot

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1670,7 +1670,6 @@
         "import io\n",
         "import mmap\n",
         "import textwrap\n",
-        "import zlib\n",
         "\n",
         "import numpy\n",
         "import numpy as np\n",


### PR DESCRIPTION
We now use `gzip` instead of `zlib` to take advantage of CRC32. So this unused `zlib` import can be dropped.