### PR TITLE
Drop `zlib` import for ROI trace plot (for 2.x)

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1471,7 +1471,6 @@
         "import io\n",
         "import mmap\n",
         "import textwrap\n",
-        "import zlib\n",
         "\n",
         "import numpy\n",
         "import numpy as np\n",


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/301 ) for 2.x.