### PR TITLE
Catch `OSError` raised by `dask_drmaa`

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -23,7 +23,7 @@ import dask.distributed
 
 try:
     import dask_drmaa
-except (ImportError, RuntimeError):
+except (ImportError, OSError, RuntimeError):
     dask_drmaa = None
 
 from builtins import (


### PR DESCRIPTION
If the `DRMAA_LIBRARY_PATH` is set to something that does not exist, then importing `dask_drmaa` (really `drmaa` under the hood) will raise an `OSError` as the library is not available to load. In this case we'd like to fallback to using `distributed` in a `multiprocessing` context. So go ahead and catch the `OSError` and skip using `dask_drmaa` as with other errors importing `dask_drmaa` may emit.