### PR TITLE
Catch `OSError` raised by `dask_drmaa` (for 2.x)

### DIFF
--- a/nanshe_workflow/par.py
+++ b/nanshe_workflow/par.py
@@ -23,7 +23,7 @@ import dask.distributed
 
 try:
     import dask_drmaa
-except (ImportError, RuntimeError):
+except (ImportError, OSError, RuntimeError):
     dask_drmaa = None
 
 from builtins import (


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/nanshe_workflow/pull/303 ) for 2.x.