### PR TITLE
Make sure `psutil`'s `cpu_count` is imported

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1279,6 +1279,7 @@
       "source": [
         "from nanshe_workflow.par import startup_distributed, shutdown_distributed\n",
         "from nanshe_workflow.data import DistributedArrayStore\n",
+        "from psutil import cpu_count\n",
         "\n",
         "\n",
         "ncores = int(os.environ.get(\"CORES\", cpu_count())) - 1\n",


### PR DESCRIPTION
Go ahead and include the `cpu_count` import before performing dictionary learning in the workflow.