### PR TITLE
Fix typo in `n_components`

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -1307,7 +1307,7 @@
         "        del dict_dask_store[k]\n",
         "\n",
         "learner = MiniBatchDictionaryLearning(\n",
-        "    n_components=len(dict_dask_store[subgroup_dict_init_data]),\n",
+        "    n_components=len(dict_dask_store[subgroup_dict_init_dict]),\n",
         "    alpha=0.2,\n",
         "    n_iter=100,\n",
         "    fit_algorithm=\"lars\",\n",


### PR DESCRIPTION
This should be the length of the initial dictionary, but it was the length of the data. However it didn't seem to matter as scikit-learn seemed to be getting this from the initial dictionary anyways. Nevertheless this argument should be fixed, so we handle this here.