### PR TITLE
Import `dask.sharedict`

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -202,6 +202,7 @@
         "import dask.array\n",
         "import dask.array.fft\n",
         "import dask.distributed\n",
+        "import dask.sharedict\n",
         "\n",
         "import dask.array as da\n",
         "\n",


### PR DESCRIPTION
As `dask.sharedict` is no longer imported by default, go ahead and import it at the top-level. This should fix some errors raised by newer versions of Dask where this is deprecated.

xref: https://github.com/dask/dask/pull/4092