### PR TITLE
Use `frames` type for Dask Array in `roll_frames`

### DIFF
--- a/nanshe_ipython.ipynb
+++ b/nanshe_ipython.ipynb
@@ -559,7 +559,7 @@
         "        roll_frames_chunk, tuple(irange(frames.ndim)),\n",
         "        frames, tuple(irange(frames.ndim)),\n",
         "        shifts, (0, frames.ndim),\n",
-        "        dtype=da_imgs.dtype,\n",
+        "        dtype=frames.dtype,\n",
         "        concatenate=True\n",
         "    )\n",
         "\n",


### PR DESCRIPTION
Somehow the `roll_frames` function was reusing state from outside the function to construct the Dask Array result type. This corrects that issue by using the type of the input data (as it should match).