### PR TITLE
Drop extra `conda update` from CI

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -34,13 +34,11 @@ build:
         name: Install for Python 2 and clean up.
         code: |-
           conda2 install -y --use-local nanshe_workflow
-          conda2 update -y --use-local --all
           conda2 clean -tipsy
     - script:
         name: Install for Python 3 and clean up.
         code: |-
           conda3 install -y --use-local nanshe_workflow
-          conda3 update -y --use-local --all
           conda3 clean -tipsy
     - script:
         name: Restrict OpenBLAS to a single thread.
@@ -91,13 +89,11 @@ build_sge:
         name: Install for Python 2 and clean up.
         code: |-
           conda2 install -y --use-local nanshe_workflow
-          conda2 update -y --use-local --all
           conda2 clean -tipsy
     - script:
         name: Install for Python 3 and clean up.
         code: |-
           conda3 install -y --use-local nanshe_workflow
-          conda3 update -y --use-local --all
           conda3 clean -tipsy
     - script:
         name: Restrict OpenBLAS to a single thread.


### PR DESCRIPTION
These lines were useful when we had to workaround some `feature` issues with Conda. However Conda has improved on that front since. Plus these update lines seem to be mainly upgrading packages that probably shouldn't be updated (e.g. their pinnings are not matched).